### PR TITLE
Fix widgets inside row containers skipping auto-width logic

### DIFF
--- a/includes/abilities/class-composite-abilities.php
+++ b/includes/abilities/class-composite-abilities.php
@@ -241,6 +241,12 @@ class Elementor_MCP_Composite_Abilities {
 	 * 4 children). This matches Elementor's native column layout
 	 * pattern. No flex_wrap or _flex_size overrides are applied.
 	 *
+	 * Widgets that are direct children of a row parent are automatically
+	 * wrapped in a column container with the same equal percentage width.
+	 * Elementor's flex model requires a container as the flex item — a
+	 * widget placed directly in a row container has no flex-basis and
+	 * will not form a proper grid column.
+	 *
 	 * @param array  $items            The declarative structure items.
 	 * @param bool   $is_inner         Whether these are nested (inner) containers.
 	 * @param string $parent_direction The parent container's flex_direction.
@@ -300,7 +306,28 @@ class Elementor_MCP_Composite_Abilities {
 				if ( ! empty( $widget_type ) ) {
 					$widget = $this->factory->create_widget( $widget_type, $settings );
 					$this->elements_created++;
-					$elements[] = $widget;
+
+					// Widgets placed directly inside a row container must be
+					// wrapped in a column container. Elementor's flexbox model
+					// requires a container as the flex item — a bare widget has
+					// no flex-basis and will not form a proper grid column; it
+					// just stretches to fill the row instead.
+					if ( $is_in_row && $child_count > 1 ) {
+						$col_settings = array(
+							'content_width' => 'full',
+							'flex_direction' => 'column',
+							'width'         => array(
+								'size' => $equal_width,
+								'unit' => '%',
+							),
+						);
+						$col            = $this->factory->create_container( $col_settings, array( $widget ) );
+						$col['isInner'] = true;
+						$this->elements_created++;
+						$elements[] = $col;
+					} else {
+						$elements[] = $widget;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

build-page may place widgets directly inside row containers without wrapping them in column containers.

The existing auto-width logic only applies to container children, so direct widget children skip this logic and render stacked vertically instead of forming equal-width columns.

This change wraps widgets placed directly inside row containers in a container so they receive the expected width handling and render as columns.

## Testing

Verified with a test page containing 4 icon-box widgets placed directly inside a row container with no manual column wrappers.

After the fix, each widget is automatically wrapped in a container and rendered as equal-width column cards instead of stacking vertically.