### PR TITLE
feat: add convenience tools for code-highlight, reviews, off-canvas, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MCP Tools for Elementor are documented in this file.
 
+## [Unreleased]
+
+- New: 5 Pro widget convenience tools — code-highlight, reviews, off-canvas, progress-tracker, search.
+- Total MCP tools increased from 92 to 97.
+
 ## [1.4.2]
 
 - Fix: Add missing `items` property to all `array` type JSON Schema definitions across 6 ability files (12 instances). VS Code and other strict MCP clients reject tools with invalid schemas, causing "tool parameters array type must have items" errors (#6).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MCP Tools for Elementor Plugin — a WordPress plugin that extends the official WordPress MCP Adapter to expose Elementor data, widgets, structures, and methods as MCP (Model Context Protocol) tools. This enables AI tools (Claude, Cursor, etc.) to create and manipulate Elementor page designs programmatically via 92 MCP tools.
+MCP Tools for Elementor Plugin — a WordPress plugin that extends the official WordPress MCP Adapter to expose Elementor data, widgets, structures, and methods as MCP (Model Context Protocol) tools. This enables AI tools (Claude, Cursor, etc.) to create and manipulate Elementor page designs programmatically via 97 MCP tools.
 
-**Current status: All phases implemented (P0/P1/P2).** Foundation layer, 7 read-only query tools, page CRUD, layout, widget, template, global, composite tools, stock images, SVG icons, custom code tools, and full widget coverage are all complete (92 MCP tools total). See `PLAN.md` for the full architectural specification.
+**Current status: All phases implemented (P0/P1/P2).** Foundation layer, 7 read-only query tools, page CRUD, layout, widget, template, global, composite tools, stock images, SVG icons, custom code tools, and full widget coverage are all complete (97 MCP tools total). See `PLAN.md` for the full architectural specification.
 
 ## Dependencies & Requirements
 
@@ -123,7 +123,7 @@ The MCP Adapter converts ability names like `elementor-mcp/list-widgets` to tool
 | Code snippets (create) | `manage_options` + `unfiltered_html` |
 | Code snippets (list) | `manage_options` |
 
-## All Implemented Tools (92 total)
+## All Implemented Tools (97 total)
 
 ### P0 — Query/Discovery (7 read-only)
 
@@ -156,7 +156,7 @@ The MCP Adapter converts ability names like `elementor-mcp/list-widgets` to tool
 | `elementor-mcp/remove-element` | Remove an element and all children (destructive) |
 | `elementor-mcp/duplicate-element` | Duplicate element with fresh IDs |
 
-### P1/P2 — Widgets (2 universal + 23 core + 16 Pro convenience)
+### P1/P2 — Widgets (2 universal + 23 core + 21 Pro convenience)
 
 | Ability Name | Purpose |
 |---|---|
@@ -201,6 +201,11 @@ The MCP Adapter converts ability names like `elementor-mcp/list-widgets` to tool
 | `elementor-mcp/add-blockquote` | Pro: styled blockquote widget |
 | `elementor-mcp/add-lottie` | Pro: Lottie animation widget |
 | `elementor-mcp/add-hotspot` | Pro: image hotspot widget |
+| `elementor-mcp/add-code-highlight` | Pro: syntax-highlighted code block widget |
+| `elementor-mcp/add-reviews` | Pro: reviews/testimonials carousel widget |
+| `elementor-mcp/add-off-canvas` | Pro: off-canvas panel widget |
+| `elementor-mcp/add-progress-tracker` | Pro: scroll progress tracker widget |
+| `elementor-mcp/add-search` | Pro: search widget with live results support |
 
 ### P2 — Templates (2 tools)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PHP](https://img.shields.io/badge/PHP-%3E%3D7.4-8892BF.svg)](https://php.net)
 [![WordPress](https://img.shields.io/badge/WordPress-%3E%3D6.8-21759B.svg)](https://wordpress.org)
 [![Elementor](https://img.shields.io/badge/Elementor-%3E%3D3.20-92003B.svg)](https://elementor.com)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-92-orange.svg)](#available-tools)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-97-orange.svg)](#available-tools)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![GitHub Issues](https://img.shields.io/github/issues/msrbuilds/elementor-mcp)](https://github.com/msrbuilds/elementor-mcp/issues)
 [![GitHub Stars](https://img.shields.io/github/stars/msrbuilds/elementor-mcp?style=social)](https://github.com/msrbuilds/elementor-mcp)
@@ -21,7 +21,7 @@ A WordPress plugin that extends the [WordPress MCP Adapter](https://github.com/W
 
 ## Features
 
-- **92 MCP Tools** covering the full Elementor page-building workflow
+- **97 MCP Tools** covering the full Elementor page-building workflow
 - **Query & Discovery** — List widgets, inspect page structures, read element settings, browse templates, view global design tokens
 - **Page Management** — Create pages, update settings, clear content, import/export templates
 - **Layout Tools** — Add flexbox containers, move/remove/duplicate elements, update containers, find elements, batch update, reorder children, get container schema

--- a/includes/abilities/class-widget-abilities.php
+++ b/includes/abilities/class-widget-abilities.php
@@ -149,6 +149,11 @@ class Elementor_MCP_Widget_Abilities {
 			$this->register_add_portfolio();
 			$this->register_add_author_box();
 			$this->register_add_login();
+			$this->register_add_code_highlight();
+			$this->register_add_reviews();
+			$this->register_add_off_canvas();
+			$this->register_add_progress_tracker();
+			$this->register_add_search();
 
 			// WooCommerce widget convenience tools (only if WooCommerce is active).
 			if ( class_exists( 'WooCommerce' ) ) {
@@ -2182,8 +2187,8 @@ class Elementor_MCP_Widget_Abilities {
 			__( 'Add Portfolio (Pro)', 'elementor-mcp' ),
 			__( 'Adds an Elementor Pro portfolio widget to display a filterable grid of posts or custom post types.', 'elementor-mcp' ),
 			array(
-				'columns'          => array( 'type' => 'integer', 'description' => __( 'Number of columns. Default: 3.', 'elementor-mcp' ) ),
-				'posts_per_page'   => array( 'type' => 'integer', 'description' => __( 'Number of posts to display. Default: 6.', 'elementor-mcp' ) ),
+				'columns'             => array( 'type' => 'integer', 'description' => __( 'Number of columns. Default: 3.', 'elementor-mcp' ) ),
+				'posts_per_page'      => array( 'type' => 'integer', 'description' => __( 'Number of posts to display. Default: 6.', 'elementor-mcp' ) ),
 				'show_filter_bar'     => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Show category filter bar. Default: no.', 'elementor-mcp' ) ),
 				'masonry'             => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Enable masonry layout. Default: no.', 'elementor-mcp' ) ),
 				'show_title'          => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Show post title overlay. Default: yes.', 'elementor-mcp' ) ),
@@ -2260,6 +2265,133 @@ class Elementor_MCP_Widget_Abilities {
 				'redirect_after_login' => 'no',
 				'redirect_url'         => '',
 				'align'                => 'left',
+			)
+		);
+	}
+
+	private function register_add_code_highlight(): void {
+		$this->register_convenience_tool(
+			'add-code-highlight',
+			__( 'Add Code Highlight (Pro)', 'elementor-mcp' ),
+			__( 'Adds a syntax-highlighted code block widget.', 'elementor-mcp' ),
+			array(
+				'code'              => array( 'type' => 'string', 'description' => __( 'The code content to display.', 'elementor-mcp' ) ),
+				'language'          => array( 'type' => 'string', 'enum' => array( 'php', 'javascript', 'css', 'html', 'python', 'bash' ), 'description' => __( 'Syntax language. Default: php.', 'elementor-mcp' ) ),
+				'theme'             => array( 'type' => 'string', 'enum' => array( 'default', 'dark', 'funky', 'okaidia', 'twilight', 'coy' ), 'description' => __( 'Color theme. Default: default.', 'elementor-mcp' ) ),
+				'line_numbers'      => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Show line numbers. Default: yes.', 'elementor-mcp' ) ),
+				'copy_to_clipboard' => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Show copy-to-clipboard button. Default: yes.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'code-highlight',
+			array(
+				'code'              => '',
+				'language'          => 'php',
+				'theme'             => 'default',
+				'line_numbers'      => 'yes',
+				'copy_to_clipboard' => 'yes',
+			)
+		);
+	}
+
+	private function register_add_reviews(): void {
+		$this->register_convenience_tool(
+			'add-reviews',
+			__( 'Add Reviews (Pro)', 'elementor-mcp' ),
+			__( 'Adds a reviews/testimonials carousel widget.', 'elementor-mcp' ),
+			array(
+				'slides_per_view' => array( 'type' => 'integer', 'description' => __( 'Number of slides visible at once. Default: 3.', 'elementor-mcp' ) ),
+				'autoplay'        => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Enable autoplay. Default: no.', 'elementor-mcp' ) ),
+				'autoplay_speed'  => array( 'type' => 'integer', 'description' => __( 'Autoplay speed in milliseconds. Default: 3000.', 'elementor-mcp' ) ),
+				'loop'            => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Enable infinite loop. Default: yes.', 'elementor-mcp' ) ),
+				'show_arrows'     => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Show navigation arrows. Default: yes.', 'elementor-mcp' ) ),
+				'pause_on_hover'  => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Pause autoplay on hover. Default: yes.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'reviews',
+			array(
+				'slides_per_view' => 3,
+				'autoplay'        => 'no',
+				'autoplay_speed'  => 3000,
+				'loop'            => 'yes',
+				'show_arrows'     => 'yes',
+				'pause_on_hover'  => 'yes',
+			)
+		);
+	}
+
+	private function register_add_off_canvas(): void {
+		$this->register_convenience_tool(
+			'add-off-canvas',
+			__( 'Add Off-Canvas (Pro)', 'elementor-mcp' ),
+			__( 'Adds an off-canvas panel widget.', 'elementor-mcp' ),
+			array(
+				'horizontal_position' => array( 'type' => 'string', 'enum' => array( 'left', 'right' ), 'description' => __( 'Panel side. Default: left.', 'elementor-mcp' ) ),
+				'vertical_position'   => array( 'type' => 'string', 'enum' => array( 'top', 'center', 'bottom' ), 'description' => __( 'Vertical alignment. Default: center.', 'elementor-mcp' ) ),
+				'width'               => array( 'type' => 'integer', 'description' => __( 'Panel width in pixels. Default: 300.', 'elementor-mcp' ) ),
+				'entrance_animation'  => array( 'type' => 'string', 'enum' => array( 'none', 'slideInLeft', 'slideInRight', 'fadeIn' ), 'description' => __( 'Open animation. Default: slideInLeft.', 'elementor-mcp' ) ),
+				'has_overlay'         => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Show background overlay. Default: yes.', 'elementor-mcp' ) ),
+				'prevent_scroll'      => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Lock body scroll when open. Default: yes.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'off-canvas',
+			array(
+				'horizontal_position' => 'left',
+				'vertical_position'   => 'center',
+				'width'               => 300,
+				'entrance_animation'  => 'slideInLeft',
+				'has_overlay'         => 'yes',
+				'prevent_scroll'      => 'yes',
+			)
+		);
+	}
+
+	private function register_add_progress_tracker(): void {
+		$this->register_convenience_tool(
+			'add-progress-tracker',
+			__( 'Add Progress Tracker (Pro)', 'elementor-mcp' ),
+			__( 'Adds a scroll progress tracker widget.', 'elementor-mcp' ),
+			array(
+				'type'          => array( 'type' => 'string', 'enum' => array( 'horizontal', 'circular' ), 'description' => __( 'Tracker style. Default: horizontal.', 'elementor-mcp' ) ),
+				'relative_to'   => array( 'type' => 'string', 'enum' => array( 'page', 'element' ), 'description' => __( 'What to track. Default: page.', 'elementor-mcp' ) ),
+				'align'         => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right' ), 'description' => __( 'Alignment. Default: left.', 'elementor-mcp' ) ),
+				'circular_size' => array( 'type' => 'integer', 'description' => __( 'Circle diameter in pixels (circular type). Default: 200.', 'elementor-mcp' ) ),
+				'circular_width' => array( 'type' => 'integer', 'description' => __( 'Circle stroke width in pixels (circular type). Default: 8.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'progress-tracker',
+			array(
+				'type'           => 'horizontal',
+				'relative_to'    => 'page',
+				'align'          => 'left',
+				'circular_size'  => 200,
+				'circular_width' => 8,
+			)
+		);
+	}
+
+	private function register_add_search(): void {
+		$this->register_convenience_tool(
+			'add-search',
+			__( 'Add Search (Pro)', 'elementor-mcp' ),
+			__( 'Adds a search widget with live results support.', 'elementor-mcp' ),
+			array(
+				'search_input_placeholder_text' => array( 'type' => 'string', 'description' => __( 'Placeholder text for the search input. Default: Search...', 'elementor-mcp' ) ),
+				'submit_trigger'                => array( 'type' => 'string', 'enum' => array( 'button', 'auto' ), 'description' => __( 'Search trigger method. Default: button.', 'elementor-mcp' ) ),
+				'submit_button_text'            => array( 'type' => 'string', 'description' => __( 'Submit button label. Default: Search.', 'elementor-mcp' ) ),
+				'live_results'                  => array( 'type' => 'string', 'enum' => array( 'yes', 'no' ), 'description' => __( 'Enable live search results dropdown. Default: no.', 'elementor-mcp' ) ),
+				'number_of_items'               => array( 'type' => 'integer', 'description' => __( 'Max results to show. Default: 5.', 'elementor-mcp' ) ),
+				'search_query_post_type'        => array( 'type' => 'string', 'description' => __( 'Post type to search. Default: any.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'search',
+			array(
+				'search_input_placeholder_text' => 'Search...',
+				'submit_trigger'                => 'button',
+				'submit_button_text'            => 'Search',
+				'live_results'                  => 'no',
+				'number_of_items'               => 5,
+				'search_query_post_type'        => 'any',
+
 			)
 		);
 	}

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -718,6 +718,31 @@ class Elementor_MCP_Admin {
 						'description' => __( 'Adds nested accordion widget where each item is a container.', 'elementor-mcp' ),
 						'badges'      => array( 'pro' ),
 					),
+					'elementor-mcp/add-code-highlight'       => array(
+						'label'       => __( 'Add Code Highlight', 'elementor-mcp' ),
+						'description' => __( 'Adds a syntax-highlighted code block widget.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-reviews'              => array(
+						'label'       => __( 'Add Reviews', 'elementor-mcp' ),
+						'description' => __( 'Adds a reviews/testimonials carousel widget.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-off-canvas'           => array(
+						'label'       => __( 'Add Off-Canvas', 'elementor-mcp' ),
+						'description' => __( 'Adds an off-canvas panel widget.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-progress-tracker'     => array(
+						'label'       => __( 'Add Progress Tracker', 'elementor-mcp' ),
+						'description' => __( 'Adds a scroll progress tracker widget.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-search'               => array(
+						'label'       => __( 'Add Search', 'elementor-mcp' ),
+						'description' => __( 'Adds a search widget with live results support.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
 				),
 			),
 			'template'         => array(


### PR DESCRIPTION
…progress-tracker, and search widgets

- add-code-highlight: code, language, theme, line_numbers, copy_to_clipboard
- add-reviews: slides_per_view, autoplay, autoplay_speed, loop, show_arrows, pause_on_hover
- add-off-canvas: horizontal_position, vertical_position, width, entrance_animation, has_overlay, prevent_scroll
- add-progress-tracker: type, relative_to, align, circular_size, circular_width
- add-search: search_input_placeholder_text, submit_trigger, submit_button_text, live_results, number_of_items, search_query_post_type
- Register all 5 in admin panel (class-admin.php)
- Update CLAUDE.md, README.md, CHANGELOG.md (92 → 97 tools)