### PR TITLE
feat: add convenience tools for theme builder widgets and register in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@
 
 A WordPress plugin that extends the [WordPress MCP Adapter](https://github.com/WordPress/mcp-adapter) to expose Elementor data, widgets, and page design tools as [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) tools. This enables AI agents like Claude, Cursor, and other MCP-compatible clients to create and manipulate Elementor page designs programmatically.
 
-<img width="1953" height="1102" alt="image" src="https://github.com/user-attachments/assets/b6fbf504-5306-41ef-a584-eaabf63b2c93" />
+<img width="1995" height="1141" alt="image" src="https://github.com/user-attachments/assets/06ab916a-0146-4a5f-828c-d5aa409cb072" />
 
+
+# 50+ Premium Prompts Pack - Generate Superior Landing Pages
+## [Grab the Deal](https://wpacademy.gumroad.com/l/vlrihk)
+<img width="1280" height="720" alt="banner" src="https://github.com/user-attachments/assets/d862b866-ca2e-4283-af22-c9464b52d746" />
 
 ## Features
 
@@ -456,3 +460,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on how to get sta
 ## License
 
 This project is licensed under the [GNU General Public License v3.0](LICENSE).
+

--- a/includes/abilities/class-widget-abilities.php
+++ b/includes/abilities/class-widget-abilities.php
@@ -146,6 +146,11 @@ class Elementor_MCP_Widget_Abilities {
 			$this->register_add_media_carousel();
 			$this->register_add_nested_tabs();
 			$this->register_add_nested_accordion();
+			$this->register_add_theme_site_logo();
+			$this->register_add_theme_site_title();
+			$this->register_add_theme_post_title();
+			$this->register_add_theme_page_title();
+			$this->register_add_theme_post_excerpt();
 
 			// WooCommerce widget convenience tools (only if WooCommerce is active).
 			if ( class_exists( 'WooCommerce' ) ) {
@@ -2170,6 +2175,112 @@ class Elementor_MCP_Widget_Abilities {
 			array(),
 			'nested-accordion',
 			array( 'default_state' => 'expanded', 'max_items_expended' => 'one' )
+		);
+	}
+
+	private function register_add_theme_site_logo(): void {
+		$this->register_convenience_tool(
+			'add-theme-site-logo',
+			__( 'Add Site Logo (Pro)', 'elementor-mcp' ),
+			__( 'Adds an Elementor Pro site logo widget that displays the logo set in Customizer > Site Identity.', 'elementor-mcp' ),
+			array(
+				'width'           => array( 'type' => 'integer', 'description' => __( 'Logo width in pixels. Default: 200.', 'elementor-mcp' ) ),
+				'align'           => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right' ), 'description' => __( 'Horizontal alignment. Default: left.', 'elementor-mcp' ) ),
+				'link_to'         => array( 'type' => 'string', 'enum' => array( 'none', 'home', 'custom' ), 'description' => __( 'Logo link destination. Default: home.', 'elementor-mcp' ) ),
+				'hover_animation' => array( 'type' => 'string', 'enum' => array( 'none', 'grow', 'shrink', 'pulse', 'push', 'bounce' ), 'description' => __( 'Hover animation preset. Default: none.', 'elementor-mcp' ) ),
+				'image_size'      => array( 'type' => 'string', 'enum' => array( 'thumbnail', 'medium', 'large', 'full' ), 'description' => __( 'Image size. Default: full.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'theme-site-logo',
+			array(
+				'width'           => 200,
+				'align'           => 'left',
+				'link_to'         => 'home',
+				'hover_animation' => 'none',
+				'image_size'      => 'full',
+			)
+		);
+	}
+
+	private function register_add_theme_site_title(): void {
+		$this->register_convenience_tool(
+			'add-theme-site-title',
+			__( 'Add Site Title (Pro)', 'elementor-mcp' ),
+			__( 'Adds an Elementor Pro site title widget that displays the site name set in Settings > General.', 'elementor-mcp' ),
+			array(
+				'header_size' => array( 'type' => 'string', 'enum' => array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span', 'p' ), 'description' => __( 'HTML tag for the title. Default: h2.', 'elementor-mcp' ) ),
+				'align'       => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right' ), 'description' => __( 'Text alignment. Default: left.', 'elementor-mcp' ) ),
+				'title_color' => array( 'type' => 'string', 'description' => __( 'Title text color (hex). Default: inherited.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'theme-site-title',
+			array(
+				'header_size' => 'h2',
+				'align'       => 'left',
+				'title_color' => '',
+			)
+		);
+	}
+
+	private function register_add_theme_post_title(): void {
+		$this->register_convenience_tool(
+			'add-theme-post-title',
+			__( 'Add Post Title (Pro)', 'elementor-mcp' ),
+			__( 'Adds an Elementor Pro post title widget that dynamically displays the current post or page title.', 'elementor-mcp' ),
+			array(
+				'header_size' => array( 'type' => 'string', 'enum' => array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span', 'p' ), 'description' => __( 'HTML tag for the title. Default: h1.', 'elementor-mcp' ) ),
+				'align'       => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right' ), 'description' => __( 'Text alignment. Default: left.', 'elementor-mcp' ) ),
+				'title_color' => array( 'type' => 'string', 'description' => __( 'Title text color (hex). Default: inherited.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'theme-post-title',
+			array(
+				'header_size' => 'h1',
+				'align'       => 'left',
+				'title_color' => '',
+			)
+		);
+	}
+
+	private function register_add_theme_page_title(): void {
+		$this->register_convenience_tool(
+			'add-theme-page-title',
+			__( 'Add Page Title (Pro)', 'elementor-mcp' ),
+			__( 'Adds an Elementor Pro page title widget that dynamically displays the current page title.', 'elementor-mcp' ),
+			array(
+				'header_size' => array( 'type' => 'string', 'enum' => array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span', 'p' ), 'description' => __( 'HTML tag for the title. Default: h1.', 'elementor-mcp' ) ),
+				'align'       => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right' ), 'description' => __( 'Text alignment. Default: left.', 'elementor-mcp' ) ),
+				'title_color' => array( 'type' => 'string', 'description' => __( 'Title text color (hex). Default: inherited.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'theme-page-title',
+			array(
+				'header_size' => 'h1',
+				'align'       => 'left',
+				'title_color' => '',
+			)
+		);
+	}
+
+	private function register_add_theme_post_excerpt(): void {
+		$this->register_convenience_tool(
+			'add-theme-post-excerpt',
+			__( 'Add Post Excerpt (Pro)', 'elementor-mcp' ),
+			__( 'Adds an Elementor Pro post excerpt widget that dynamically displays the current post excerpt.', 'elementor-mcp' ),
+			array(
+				'align'             => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right', 'justify' ), 'description' => __( 'Text alignment. Default: left.', 'elementor-mcp' ) ),
+				'paragraph_spacing' => array( 'type' => 'integer', 'description' => __( 'Space between paragraphs in pixels. Default: 15.', 'elementor-mcp' ) ),
+				'title_color'       => array( 'type' => 'string', 'description' => __( 'Excerpt text color (hex). Default: inherited.', 'elementor-mcp' ) ),
+				'link_color'        => array( 'type' => 'string', 'description' => __( 'Link text color (hex). Default: inherited.', 'elementor-mcp' ) ),
+			),
+			array(),
+			'theme-post-excerpt',
+			array(
+				'align'             => 'left',
+				'paragraph_spacing' => 15,
+				'title_color'       => '',
+				'link_color'        => '',
+			)
 		);
 	}
 

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -718,6 +718,46 @@ class Elementor_MCP_Admin {
 						'description' => __( 'Adds nested accordion widget where each item is a container.', 'elementor-mcp' ),
 						'badges'      => array( 'pro' ),
 					),
+					'elementor-mcp/add-portfolio'            => array(
+						'label'       => __( 'Add Portfolio', 'elementor-mcp' ),
+						'description' => __( 'Adds a portfolio widget to display a filterable grid of posts.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-author-box'           => array(
+						'label'       => __( 'Add Author Box', 'elementor-mcp' ),
+						'description' => __( 'Adds an author box widget displaying author info.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-login'                => array(
+						'label'       => __( 'Add Login', 'elementor-mcp' ),
+						'description' => __( 'Adds a login form widget.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-theme-site-logo'      => array(
+						'label'       => __( 'Add Site Logo', 'elementor-mcp' ),
+						'description' => __( 'Adds the site logo from Customizer.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-theme-site-title'     => array(
+						'label'       => __( 'Add Site Title', 'elementor-mcp' ),
+						'description' => __( 'Adds the site name dynamically.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-theme-post-title'     => array(
+						'label'       => __( 'Add Post Title', 'elementor-mcp' ),
+						'description' => __( 'Adds the current post title dynamically.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-theme-page-title'     => array(
+						'label'       => __( 'Add Page Title', 'elementor-mcp' ),
+						'description' => __( 'Adds the current page title dynamically.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
+					'elementor-mcp/add-theme-post-excerpt'   => array(
+						'label'       => __( 'Add Post Excerpt', 'elementor-mcp' ),
+						'description' => __( 'Adds the current post excerpt dynamically.', 'elementor-mcp' ),
+						'badges'      => array( 'pro' ),
+					),
 				),
 			),
 			'template'         => array(


### PR DESCRIPTION
… admin panel

- add-theme-site-logo: width, align, link_to, hover_animation, image_size
- add-theme-site-title: header_size, align, title_color
- add-theme-post-title: header_size, align, title_color
- add-theme-page-title: header_size, align, title_color
- add-theme-post-excerpt: align, paragraph_spacing, title_color, link_color
- Register all 5 theme builder tools in class-admin.php
- Also register portfolio, author-box, login in admin panel (missing from previous PR)