### PR TITLE
fix(atomic): return WP_Error when parent element not found in insert

### DIFF
--- a/includes/abilities/class-atomic-layout-abilities.php
+++ b/includes/abilities/class-atomic-layout-abilities.php
@@ -162,7 +162,10 @@ class Elementor_MCP_Atomic_Layout_Abilities {
 		}
 
 		if ( ! empty( $parent_id ) ) {
-			$inserted = $this->data->insert_element( $page_data, $parent_id, $element, $position );
+			$ok = $this->data->insert_element( $page_data, $parent_id, $element, $position );
+			if ( ! $ok ) {
+				return new \WP_Error( 'not_found', "Parent element '{$parent_id}' not found in page {$post_id}." );
+			}
 		} else {
 			// Top-level element.
 			if ( -1 === $position || $position >= count( $page_data ) ) {
@@ -170,14 +173,9 @@ class Elementor_MCP_Atomic_Layout_Abilities {
 			} else {
 				array_splice( $page_data, max( 0, $position ), 0, array( $element ) );
 			}
-			$inserted = $page_data;
 		}
 
-		if ( is_wp_error( $inserted ) ) {
-			return $inserted;
-		}
-
-		$save = $this->data->save_page_data( $post_id, $inserted );
+		$save = $this->data->save_page_data( $post_id, $page_data );
 		if ( is_wp_error( $save ) ) {
 			return $save;
 		}

--- a/includes/abilities/class-atomic-widget-abilities.php
+++ b/includes/abilities/class-atomic-widget-abilities.php
@@ -282,12 +282,12 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 						return $page_data;
 					}
 
-					$inserted = $this->data->insert_element( $page_data, $parent_id, $element, $position );
-					if ( is_wp_error( $inserted ) ) {
-						return $inserted;
+					$ok = $this->data->insert_element( $page_data, $parent_id, $element, $position );
+					if ( ! $ok ) {
+						return new \WP_Error( 'not_found', "Parent element '{$parent_id}' not found in page {$post_id}." );
 					}
 
-					$save = $this->data->save_page_data( $post_id, $inserted );
+					$save = $this->data->save_page_data( $post_id, $page_data );
 					if ( is_wp_error( $save ) ) {
 						return $save;
 					}


### PR DESCRIPTION
## Summary
- Fixes two bugs in the atomic element insertion path where `save_page_data()` was called with a `bool` instead of the actual page data
- When a `parent_id` is not found, both callers now return a descriptive `WP_Error` instead of silently saving `false`

## Why
`insert_element()` mutates `$page_data` by reference and returns `bool` — not the updated array. Both callers had two compounding bugs:

1. `is_wp_error($inserted)` on the bool return was dead code — a bool is never a `WP_Error`, so this guard never triggered
2. `save_page_data($post_id, $inserted)` passed the bool (`true` or `false`) instead of `$page_data`

In `class-atomic-widget-abilities.php` (which always requires a `parent_id`), this meant **every** atomic widget insertion — success or failure — was calling `save_page_data()` with `true` or `false` instead of the actual page array.

In `class-atomic-layout-abilities.php`, the same issue affected the nested insertion path (when `parent_id` is provided). The top-level path was not broken.

## Changes
- **Both files**: renamed `$inserted` → `$ok`; replaced the dead `is_wp_error()` check with a proper `if ( ! $ok )` guard that returns `WP_Error( 'not_found', ... )`; pass `$page_data` (already mutated by reference) to `save_page_data()`
- **`class-atomic-layout-abilities.php`**: removed the now-redundant `$inserted = $page_data` assignment from the top-level (no parent) branch

## Testing
Run a prompt like:

> Use `add-atomic-heading` with `post_id` set to any valid page ID, `parent_id` set to `"nonexistent123"`, and `title` set to `"Failure path test"`

- **Before fix**: page data silently saved as `false`; the call appeared to succeed
- **After fix**: MCP tool returns `"Parent element 'nonexistent123' not found in page X."`

## Risks
- Low. The failure path now returns a clear, actionable error. The success path now correctly persists `$page_data`, which was the original intent.

## Rollout / rollback
- Rollout: standard plugin update — no DB migrations, no config changes
- Rollback: revert to the previous plugin version; no side effects