### PR TITLE
Fix: register atomic (V4) tools only when atomic writes will persist

### DIFF
--- a/includes/class-atomic-props.php
+++ b/includes/class-atomic-props.php
@@ -237,11 +237,44 @@ class Elementor_MCP_Atomic_Props {
 	}
 
 	/**
-	 * Checks whether Elementor 4.0+ atomic elements are available.
+	 * Checks whether Elementor atomic (V4) elements are available.
+	 *
+	 * Detection is not version-number based. Elementor ships the atomic / V4
+	 * editor as opt-in experiments *while the core `ELEMENTOR_VERSION` constant
+	 * still reports a 3.x value* (e.g. 3.31.5 with the "e_opt_in_v4_page"
+	 * experiment active even though the plugin markets itself as 4.x). Gating on
+	 * `version_compare( ELEMENTOR_VERSION, '4.0.0', '>=' )` therefore returns
+	 * false on exactly the sites that are running atomic, so the atomic tools
+	 * never register and content writes fall back to the classic format (which
+	 * does not persist on an atomic page).
+	 *
+	 * So: treat atomic as supported when an atomic experiment is active, OR the
+	 * atomic widgets module is loaded, OR the version constant is genuinely 4.0+.
 	 *
 	 * @return bool True if atomic elements are supported.
 	 */
 	public static function is_atomic_supported(): bool {
+		// Experiment flags (any active ⇒ atomic editor is in play). Guarded with
+		// method_exists so we never fatal on Elementor builds (or test stubs)
+		// that don't expose the experiments API.
+		if ( class_exists( '\Elementor\Plugin' ) && method_exists( '\Elementor\Plugin', 'instance' ) ) {
+			$elementor = \Elementor\Plugin::instance();
+			if ( isset( $elementor->experiments ) && is_object( $elementor->experiments )
+				&& method_exists( $elementor->experiments, 'is_feature_active' ) ) {
+				foreach ( array( 'e_opt_in_v4_page', 'e_atomic_elements', 'atomic_widgets', 'editor_v4' ) as $feature ) {
+					if ( $elementor->experiments->is_feature_active( $feature ) ) {
+						return true;
+					}
+				}
+			}
+		}
+
+		// Atomic widgets module present (loaded independently of the version string).
+		if ( class_exists( '\Elementor\Modules\AtomicWidgets\Module' ) ) {
+			return true;
+		}
+
+		// Genuine 4.0+ core (kept as a forward-compatible fallback).
 		return defined( 'ELEMENTOR_VERSION' ) && version_compare( ELEMENTOR_VERSION, '4.0.0', '>=' );
 	}
 }

--- a/includes/class-atomic-props.php
+++ b/includes/class-atomic-props.php
@@ -237,31 +237,47 @@ class Elementor_MCP_Atomic_Props {
 	}
 
 	/**
-	 * Checks whether Elementor atomic (V4) elements are available.
+	 * Checks whether Elementor atomic (V4) elements are available **and will
+	 * persist**.
 	 *
-	 * Detection is not version-number based. Elementor ships the atomic / V4
-	 * editor as opt-in experiments *while the core `ELEMENTOR_VERSION` constant
-	 * still reports a 3.x value* (e.g. 3.31.5 with the "e_opt_in_v4_page"
-	 * experiment active even though the plugin markets itself as 4.x). Gating on
-	 * `version_compare( ELEMENTOR_VERSION, '4.0.0', '>=' )` therefore returns
-	 * false on exactly the sites that are running atomic, so the atomic tools
-	 * never register and content writes fall back to the classic format (which
-	 * does not persist on an atomic page).
+	 * Detection is not version-number based. Elementor ships atomic/V4 as opt-in
+	 * experiments while the core `ELEMENTOR_VERSION` constant still reports a 3.x
+	 * value, so `version_compare( ELEMENTOR_VERSION, '4.0.0', '>=' )` is false on
+	 * exactly the sites running atomic.
 	 *
-	 * So: treat atomic as supported when an atomic experiment is active, OR the
-	 * atomic widgets module is loaded, OR the version constant is genuinely 4.0+.
+	 * Crucially, we gate on whether the atomic **element types are registered**
+	 * (`e-flexbox` / `e-div-block`), not merely whether the V4 *page* editor is
+	 * opted in. Those are separate experiments: a site can have `e_opt_in_v4_page`
+	 * active while `e_atomic_elements` is OFF — atomic tools would register, but
+	 * `Elementor\Document::save()` then silently sanitizes the unknown elements
+	 * away (the write returns success yet `_elementor_data` stays empty). Keying
+	 * on element-type registration means the atomic tools appear only when an
+	 * atomic write will actually persist. Verified live on Elementor 3.31.5.
 	 *
-	 * @return bool True if atomic elements are supported.
+	 * @return bool True if atomic element types are registered/available.
 	 */
 	public static function is_atomic_supported(): bool {
-		// Experiment flags (any active ⇒ atomic editor is in play). Guarded with
-		// method_exists so we never fatal on Elementor builds (or test stubs)
-		// that don't expose the experiments API.
 		if ( class_exists( '\Elementor\Plugin' ) && method_exists( '\Elementor\Plugin', 'instance' ) ) {
 			$elementor = \Elementor\Plugin::instance();
+
+			// Primary, authoritative signal: the atomic element types are
+			// registered server-side, so Document::save() will keep them.
+			if ( isset( $elementor->elements_manager ) && is_object( $elementor->elements_manager )
+				&& method_exists( $elementor->elements_manager, 'get_element_types' ) ) {
+				$types = $elementor->elements_manager->get_element_types();
+				if ( is_array( $types ) && ( isset( $types['e-flexbox'] ) || isset( $types['e-div-block'] ) ) ) {
+					return true;
+				}
+			}
+
+			// Secondary: the experiments that register the atomic element types.
+			// (Deliberately NOT e_opt_in_v4_page / editor_v4 — those opt the page
+			// editor into V4 without guaranteeing element registration, which is
+			// the silent-no-op trap above.) method_exists-guarded so we never
+			// fatal on builds/stubs without the experiments API.
 			if ( isset( $elementor->experiments ) && is_object( $elementor->experiments )
 				&& method_exists( $elementor->experiments, 'is_feature_active' ) ) {
-				foreach ( array( 'e_opt_in_v4_page', 'e_atomic_elements', 'atomic_widgets', 'editor_v4' ) as $feature ) {
+				foreach ( array( 'e_atomic_elements', 'atomic_widgets' ) as $feature ) {
 					if ( $elementor->experiments->is_feature_active( $feature ) ) {
 						return true;
 					}
@@ -269,10 +285,10 @@ class Elementor_MCP_Atomic_Props {
 			}
 		}
 
-		// Atomic widgets module present (loaded independently of the version string).
-		if ( class_exists( '\Elementor\Modules\AtomicWidgets\Module' ) ) {
-			return true;
-		}
+		// NB: do NOT use class_exists( '\Elementor\Modules\AtomicWidgets\Module' )
+		// as a signal — that class is autoloaded even when the atomic experiment
+		// is OFF and no atomic element types are registered, which would make the
+		// tools register while writes silently get dropped on save.
 
 		// Genuine 4.0+ core (kept as a forward-compatible fallback).
 		return defined( 'ELEMENTOR_VERSION' ) && version_compare( ELEMENTOR_VERSION, '4.0.0', '>=' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,6 +44,14 @@ namespace {
 	$GLOBALS['_caps'] = null;
 
 	// -----------------------------------------------------------------------
+	// Active Elementor experiments for atomic-detection tests.
+	// $GLOBALS['_active_experiments'] lists the experiment slugs the
+	// \Elementor\Plugin stub's experiments->is_feature_active() reports active.
+	// Reset per-test in setUp(); empty by default.
+	// -----------------------------------------------------------------------
+	$GLOBALS['_active_experiments'] = [];
+
+	// -----------------------------------------------------------------------
 	// WordPress function stubs
 	// -----------------------------------------------------------------------
 
@@ -485,7 +493,23 @@ namespace Elementor {
 			/** @var object Stub kits_manager returning null (no active kit). */
 			public $kits_manager;
 
+			/** @var object Stub experiments manager reading $GLOBALS['_active_experiments']. */
+			public $experiments;
+
 			private function __construct() {
+				$this->experiments = new class {
+					/**
+					 * Reports an experiment active iff its slug is in
+					 * $GLOBALS['_active_experiments'] (set per-test).
+					 *
+					 * @param string $feature Experiment slug.
+					 * @return bool
+					 */
+					public function is_feature_active( string $feature ): bool {
+						return in_array( $feature, $GLOBALS['_active_experiments'] ?? [], true );
+					}
+				};
+
 				$this->documents = new class {
 					public function get( int $post_id ) {
 						return null;
@@ -519,6 +543,11 @@ namespace Elementor {
 				}
 				return static::$instance;
 			}
+
+			/** Real Elementor exposes the singleton via instance(); mirror it. */
+			public static function instance(): self {
+				return static::getInstance();
+			}
 		}
 
 		Plugin::$instance = Plugin::getInstance();
@@ -537,6 +566,7 @@ namespace {
 
 		$map = [
 			// Core classes
+			'Elementor_MCP_Atomic_Props'           => 'includes/class-atomic-props.php',
 			'Elementor_MCP_Data'                  => 'includes/class-elementor-data.php',
 			'Elementor_MCP_Element_Factory'        => 'includes/class-element-factory.php',
 			'Elementor_MCP_Id_Generator'           => 'includes/class-id-generator.php',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,6 +52,14 @@ namespace {
 	$GLOBALS['_active_experiments'] = [];
 
 	// -----------------------------------------------------------------------
+	// Registered atomic element types for atomic-detection tests.
+	// $GLOBALS['_registered_element_types'] lists the element-type slugs the
+	// \Elementor\Plugin stub's elements_manager->get_element_types() returns
+	// (e.g. 'e-flexbox'). Reset per-test in setUp(); empty by default.
+	// -----------------------------------------------------------------------
+	$GLOBALS['_registered_element_types'] = [];
+
+	// -----------------------------------------------------------------------
 	// WordPress function stubs
 	// -----------------------------------------------------------------------
 
@@ -496,6 +504,9 @@ namespace Elementor {
 			/** @var object Stub experiments manager reading $GLOBALS['_active_experiments']. */
 			public $experiments;
 
+			/** @var object Stub elements_manager reading $GLOBALS['_registered_element_types']. */
+			public $elements_manager;
+
 			private function __construct() {
 				$this->experiments = new class {
 					/**
@@ -507,6 +518,22 @@ namespace Elementor {
 					 */
 					public function is_feature_active( string $feature ): bool {
 						return in_array( $feature, $GLOBALS['_active_experiments'] ?? [], true );
+					}
+				};
+
+				$this->elements_manager = new class {
+					/**
+					 * Returns a map of registered element types keyed by slug,
+					 * driven by $GLOBALS['_registered_element_types'] (set per-test).
+					 *
+					 * @return array<string, object>
+					 */
+					public function get_element_types(): array {
+						$out = [];
+						foreach ( $GLOBALS['_registered_element_types'] ?? [] as $slug ) {
+							$out[ $slug ] = new \stdClass();
+						}
+						return $out;
 					}
 				};
 

--- a/tests/unit/regression/AtomicDetectionRegressionTest.php
+++ b/tests/unit/regression/AtomicDetectionRegressionTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Regression tests — atomic (V4) detection.
+ *
+ * Elementor ships the atomic / V4 editor as opt-in experiments while the core
+ * `ELEMENTOR_VERSION` constant can still report a 3.x value (observed in the
+ * wild: 3.31.5 with the `e_opt_in_v4_page` experiment active even though the
+ * plugin markets itself as 4.x). The previous detection —
+ *   version_compare( ELEMENTOR_VERSION, '4.0.0', '>=' )
+ * returned false on exactly those sites, so the atomic tools never registered
+ * and content writes silently fell back to the classic format (which does not
+ * persist on an atomic page).
+ *
+ * Elementor_MCP_Atomic_Props::is_atomic_supported() now also treats atomic as
+ * supported when an atomic experiment is active (or the AtomicWidgets module is
+ * loaded). These tests lock that behaviour in.
+ *
+ * @group regression
+ * @group atomic
+ * @package Elementor_MCP\Tests\Regression
+ */
+
+namespace Elementor_MCP\Tests\Regression;
+
+use PHPUnit\Framework\TestCase;
+
+class AtomicDetectionRegressionTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['_active_experiments'] = [];
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['_active_experiments'] = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 *
+	 * No atomic experiment active + a 3.x ELEMENTOR_VERSION (the bootstrap sets
+	 * 3.25.0) → classic site → atomic NOT supported.
+	 */
+	public function classic_site_without_experiment_is_not_atomic(): void {
+		$this->assertFalse( \Elementor_MCP_Atomic_Props::is_atomic_supported() );
+	}
+
+	/**
+	 * @test
+	 *
+	 * The exact real-world breakage: 3.x version string but the V4 page
+	 * experiment is active → MUST be detected as atomic.
+	 */
+	public function v4_page_experiment_marks_atomic_supported(): void {
+		$GLOBALS['_active_experiments'] = [ 'e_opt_in_v4_page' ];
+		$this->assertTrue( \Elementor_MCP_Atomic_Props::is_atomic_supported() );
+	}
+
+	/**
+	 * @test
+	 *
+	 * Any of the recognised atomic experiment slugs flips detection on.
+	 *
+	 * @dataProvider atomic_experiment_provider
+	 */
+	public function each_atomic_experiment_marks_atomic_supported( string $slug ): void {
+		$GLOBALS['_active_experiments'] = [ $slug ];
+		$this->assertTrue( \Elementor_MCP_Atomic_Props::is_atomic_supported(), "Experiment '$slug' should enable atomic." );
+	}
+
+	/**
+	 * @return array<string, array{0:string}>
+	 */
+	public static function atomic_experiment_provider(): array {
+		return [
+			'e_opt_in_v4_page'  => [ 'e_opt_in_v4_page' ],
+			'e_atomic_elements' => [ 'e_atomic_elements' ],
+			'atomic_widgets'    => [ 'atomic_widgets' ],
+			'editor_v4'         => [ 'editor_v4' ],
+		];
+	}
+
+	/**
+	 * @test
+	 *
+	 * An unrelated active experiment must NOT be mistaken for atomic.
+	 */
+	public function unrelated_experiment_does_not_enable_atomic(): void {
+		$GLOBALS['_active_experiments'] = [ 'some_other_feature' ];
+		$this->assertFalse( \Elementor_MCP_Atomic_Props::is_atomic_supported() );
+	}
+}

--- a/tests/unit/regression/AtomicDetectionRegressionTest.php
+++ b/tests/unit/regression/AtomicDetectionRegressionTest.php
@@ -2,18 +2,21 @@
 /**
  * Regression tests — atomic (V4) detection.
  *
- * Elementor ships the atomic / V4 editor as opt-in experiments while the core
- * `ELEMENTOR_VERSION` constant can still report a 3.x value (observed in the
- * wild: 3.31.5 with the `e_opt_in_v4_page` experiment active even though the
- * plugin markets itself as 4.x). The previous detection —
- *   version_compare( ELEMENTOR_VERSION, '4.0.0', '>=' )
- * returned false on exactly those sites, so the atomic tools never registered
- * and content writes silently fell back to the classic format (which does not
- * persist on an atomic page).
+ * Two separate facts about Elementor's atomic/V4 rollout drive this:
  *
- * Elementor_MCP_Atomic_Props::is_atomic_supported() now also treats atomic as
- * supported when an atomic experiment is active (or the AtomicWidgets module is
- * loaded). These tests lock that behaviour in.
+ *  1. `ELEMENTOR_VERSION` can still read 3.x while atomic is active, so a
+ *     version_compare gate misses real atomic sites.
+ *  2. Atomic tooling is only useful when atomic **writes persist**, and that
+ *     happens only once the atomic element *types* (`e-flexbox`/`e-div-block`)
+ *     are registered server-side — which is gated by the `e_atomic_elements`
+ *     experiment, NOT by the `e_opt_in_v4_page` page-editor opt-in. A site can
+ *     have `e_opt_in_v4_page` on while `e_atomic_elements` is off; there the
+ *     atomic tools would register but `Document::save()` silently drops the
+ *     unknown elements (write "succeeds", `_elementor_data` stays empty).
+ *
+ * So is_atomic_supported() keys on element-type registration (or the experiment
+ * that produces it), and deliberately ignores the page-opt-in experiment. These
+ * tests lock that in. Verified live on Elementor 3.31.5.
  *
  * @group regression
  * @group atomic
@@ -28,43 +31,53 @@ class AtomicDetectionRegressionTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$GLOBALS['_active_experiments'] = [];
+		$GLOBALS['_active_experiments']       = [];
+		$GLOBALS['_registered_element_types'] = [];
 	}
 
 	protected function tearDown(): void {
-		$GLOBALS['_active_experiments'] = [];
+		$GLOBALS['_active_experiments']       = [];
+		$GLOBALS['_registered_element_types'] = [];
 		parent::tearDown();
 	}
 
 	/**
 	 * @test
-	 *
-	 * No atomic experiment active + a 3.x ELEMENTOR_VERSION (the bootstrap sets
-	 * 3.25.0) → classic site → atomic NOT supported.
+	 * Classic site: no atomic experiment, no atomic element types → not atomic.
 	 */
-	public function classic_site_without_experiment_is_not_atomic(): void {
+	public function classic_site_is_not_atomic(): void {
 		$this->assertFalse( \Elementor_MCP_Atomic_Props::is_atomic_supported() );
 	}
 
 	/**
 	 * @test
+	 * Authoritative signal: the atomic element types are registered → atomic,
+	 * even with no experiment flag readable.
 	 *
-	 * The exact real-world breakage: 3.x version string but the V4 page
-	 * experiment is active → MUST be detected as atomic.
+	 * @dataProvider registered_type_provider
 	 */
-	public function v4_page_experiment_marks_atomic_supported(): void {
-		$GLOBALS['_active_experiments'] = [ 'e_opt_in_v4_page' ];
-		$this->assertTrue( \Elementor_MCP_Atomic_Props::is_atomic_supported() );
+	public function registered_atomic_element_type_marks_atomic_supported( string $slug ): void {
+		$GLOBALS['_registered_element_types'] = [ $slug ];
+		$this->assertTrue( \Elementor_MCP_Atomic_Props::is_atomic_supported(), "Registered type '$slug' should enable atomic." );
+	}
+
+	/**
+	 * @return array<string, array{0:string}>
+	 */
+	public static function registered_type_provider(): array {
+		return [
+			'e-flexbox'   => [ 'e-flexbox' ],
+			'e-div-block' => [ 'e-div-block' ],
+		];
 	}
 
 	/**
 	 * @test
-	 *
-	 * Any of the recognised atomic experiment slugs flips detection on.
+	 * The experiments that actually register atomic element types → atomic.
 	 *
 	 * @dataProvider atomic_experiment_provider
 	 */
-	public function each_atomic_experiment_marks_atomic_supported( string $slug ): void {
+	public function atomic_element_experiment_marks_atomic_supported( string $slug ): void {
 		$GLOBALS['_active_experiments'] = [ $slug ];
 		$this->assertTrue( \Elementor_MCP_Atomic_Props::is_atomic_supported(), "Experiment '$slug' should enable atomic." );
 	}
@@ -74,19 +87,31 @@ class AtomicDetectionRegressionTest extends TestCase {
 	 */
 	public static function atomic_experiment_provider(): array {
 		return [
-			'e_opt_in_v4_page'  => [ 'e_opt_in_v4_page' ],
 			'e_atomic_elements' => [ 'e_atomic_elements' ],
 			'atomic_widgets'    => [ 'atomic_widgets' ],
-			'editor_v4'         => [ 'editor_v4' ],
 		];
 	}
 
 	/**
 	 * @test
 	 *
-	 * An unrelated active experiment must NOT be mistaken for atomic.
+	 * THE KEY REGRESSION: the V4 *page* opt-in alone, with no atomic element
+	 * types registered, must NOT report atomic — otherwise the tools register
+	 * but writes silently no-op.
 	 */
-	public function unrelated_experiment_does_not_enable_atomic(): void {
+	public function v4_page_optin_alone_is_not_atomic(): void {
+		$GLOBALS['_active_experiments'] = [ 'e_opt_in_v4_page' ]; // page editor opt-in only
+		$this->assertFalse(
+			\Elementor_MCP_Atomic_Props::is_atomic_supported(),
+			'e_opt_in_v4_page without registered atomic element types must not enable atomic tools.'
+		);
+	}
+
+	/**
+	 * @test
+	 * An unrelated active experiment must not be mistaken for atomic.
+	 */
+	public function unrelated_experiment_is_not_atomic(): void {
 		$GLOBALS['_active_experiments'] = [ 'some_other_feature' ];
 		$this->assertFalse( \Elementor_MCP_Atomic_Props::is_atomic_supported() );
 	}


### PR DESCRIPTION
## Problem

On a site running the atomic / V4 editor, atomic content writes silently failed to persist. Two compounding causes, both traced live on Elementor 3.31.5 (WP-CLI):

**1. Atomic tools never registered.** `is_atomic_supported()` gated on the version constant:

```php
return defined('ELEMENTOR_VERSION') && version_compare(ELEMENTOR_VERSION, '4.0.0', '>=');
```

But Elementor runs atomic as opt-in experiments while `ELEMENTOR_VERSION` still reads `3.31.5`, so this is `false` on exactly the atomic sites → the atomic ability classes `return` early in `register()` → no atomic tools.

**2. Even once registered, writes didn't persist.** Registering the tools on the *page* opt-in (`e_opt_in_v4_page`) isn't enough: the atomic **element types** (`e-flexbox` / `e-div-block`) are only registered server-side when the **`e_atomic_elements`** experiment is on. A site can have `e_opt_in_v4_page` on while `e_atomic_elements` is off — there `add-flexbox` returns an `element_id` but `Document::save()` silently sanitizes the unknown element out and `_elementor_data` stays `[]` (the write "succeeds" yet nothing persists).

## Fix

Make `is_atomic_supported()` key on whether atomic writes will actually persist — i.e. whether the atomic element types are registered:

- **Primary:** `elements_manager->get_element_types()` contains `e-flexbox` / `e-div-block`.
- **Secondary:** the experiments that produce that registration — `e_atomic_elements`, `atomic_widgets`.
- **Deliberately dropped:** `e_opt_in_v4_page` / `editor_v4` (page-editor opt-in ⇒ tools-without-persistence, the silent no-op), and the `\Elementor\Modules\AtomicWidgets\Module` `class_exists` check (the class is autoloaded even when the feature is off and nothing is registered).
- **Kept:** the genuine `ELEMENTOR_VERSION >= 4.0.0` fallback.

All Elementor access is `method_exists`-guarded so it can't fatal on builds/stubs without the experiments / elements-manager API.

## Verified live (Elementor 3.31.5 + Pro)

| State | `is_atomic_supported()` | atomic tools | `add-flexbox` write |
|---|---|---|---|
| `e_atomic_elements` ON  | **true**  | register | **persists** (`e-flexbox` present in `export-page`) |
| only `e_opt_in_v4_page` | **false** | don't register | n/a — agent stays on the classic path instead of silently no-opping |

End-to-end through the MCP (initialize → tools/list → create-page → add-flexbox → export-page) confirms the element persists in `_elementor_data` when supported.

## Tests

- `tests/unit/regression/AtomicDetectionRegressionTest.php`: registered element type → true; `e_atomic_elements` / `atomic_widgets` → true; **`e_opt_in_v4_page` alone → false** (the key regression); unrelated experiment → false; classic → false.
- `tests/bootstrap.php` (additive): `experiments` + `elements_manager` stubs on `\Elementor\Plugin` (read `$GLOBALS['_active_experiments']` / `$GLOBALS['_registered_element_types']`), a `Plugin::instance()` alias, and an autoload entry for `Elementor_MCP_Atomic_Props`.
- Suite: 336 → 343 tests, **+7 passing**, the pre-existing 18 errors / 15 failures unchanged. `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)