### PR TITLE
Fix: atomic add/update tools pass page-data array (not bool) to save_page_data

### DIFF
--- a/includes/abilities/class-atomic-layout-abilities.php
+++ b/includes/abilities/class-atomic-layout-abilities.php
@@ -279,7 +279,11 @@ class Elementor_MCP_Atomic_Layout_Abilities {
 			return $inserted;
 		}
 
-		$save = $this->data->save_page_data( $post_id, $inserted );
+		// In the nested-insert branch above, insert_element() returns a bool and
+		// mutates $page_data by reference; only the top-level branch sets
+		// $inserted to the array. Save $page_data so a nested add-flexbox /
+		// add-div-block (non-empty parent_id) doesn't hit a TypeError.
+		$save = $this->data->save_page_data( $post_id, $page_data );
 		if ( is_wp_error( $save ) ) {
 			return $save;
 		}

--- a/includes/abilities/class-atomic-widget-abilities.php
+++ b/includes/abilities/class-atomic-widget-abilities.php
@@ -153,7 +153,10 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 			return $inserted;
 		}
 
-		$save = $this->data->save_page_data( $post_id, $inserted );
+		// insert_element() returns a bool and mutates $page_data by reference.
+		// save_page_data() expects the page-data array — passing $inserted (bool)
+		// here raised a TypeError and broke add-atomic-widget entirely.
+		$save = $this->data->save_page_data( $post_id, $page_data );
 		if ( is_wp_error( $save ) ) {
 			return $save;
 		}
@@ -213,7 +216,10 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 			return $updated;
 		}
 
-		$save = $this->data->save_page_data( $post_id, $updated );
+		// update_element_settings() returns a bool and mutates $page_data by
+		// reference — pass the array, not the bool (same TypeError class as
+		// add-atomic-widget above).
+		$save = $this->data->save_page_data( $post_id, $page_data );
 		if ( is_wp_error( $save ) ) {
 			return $save;
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -594,6 +594,7 @@ namespace {
 		$map = [
 			// Core classes
 			'Elementor_MCP_Atomic_Props'           => 'includes/class-atomic-props.php',
+			'Elementor_MCP_Atomic_Styles'          => 'includes/class-atomic-styles.php',
 			'Elementor_MCP_Data'                  => 'includes/class-elementor-data.php',
 			'Elementor_MCP_Element_Factory'        => 'includes/class-element-factory.php',
 			'Elementor_MCP_Id_Generator'           => 'includes/class-id-generator.php',
@@ -619,6 +620,8 @@ namespace {
 			'Elementor_MCP_Global_Abilities'       => 'includes/abilities/class-global-abilities.php',
 			'Elementor_MCP_Template_Abilities'     => 'includes/abilities/class-template-abilities.php',
 			'Elementor_MCP_Widget_Abilities'       => 'includes/abilities/class-widget-abilities.php',
+			'Elementor_MCP_Atomic_Widget_Abilities' => 'includes/abilities/class-atomic-widget-abilities.php',
+			'Elementor_MCP_Atomic_Layout_Abilities' => 'includes/abilities/class-atomic-layout-abilities.php',
 		];
 
 		if ( isset( $map[ $class ] ) ) {

--- a/tests/unit/regression/AtomicSaveRegressionTest.php
+++ b/tests/unit/regression/AtomicSaveRegressionTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Regression — atomic save path must pass the page-data array, not a bool.
+ *
+ * Three atomic ability methods built the element, mutated the page-data array
+ * by reference via a bool-returning helper, then passed that bool to
+ * save_page_data():
+ *
+ *   - execute_add_atomic_widget()    -> insert_element() returns bool
+ *   - execute_update_atomic_widget() -> update_element_settings() returns bool
+ *   - execute_add_flexbox/div_block() -> insert_element() returns bool in the
+ *                                        nested-parent branch
+ *
+ * save_page_data() is typed `array $data`, so passing the bool raised a
+ * TypeError and broke the tool. The top-level add-flexbox path happened to set
+ * the var to the array, which is why a top-level flexbox "worked" while a
+ * nested one (non-empty parent_id) blew up.
+ *
+ * Each test drives the nested branch (a real parent element exists in the page)
+ * so the helper returns a bool, and asserts the call returns the normal result
+ * array instead of throwing. The data stub's `array $data` parameter is the
+ * guard: a bool would TypeError before any assertion runs.
+ *
+ * @group regression
+ * @group atomic
+ * @package Elementor_MCP\Tests\Regression
+ */
+
+namespace Elementor_MCP\Tests\Regression;
+
+require_once dirname( __DIR__ ) . '/class-ability-test-case.php';
+
+use Elementor_MCP\Tests\Ability_Test_Case;
+
+class AtomicSaveRegressionTest extends Ability_Test_Case {
+
+	/**
+	 * Data stub whose page already contains a parent flexbox with one child
+	 * widget, so nested inserts/updates resolve and the by-ref helpers return a
+	 * bool. save_page_data() keeps the real `array $data` type hint.
+	 */
+	private function make_nested_page_stub(): \Elementor_MCP_Data {
+		return new class extends \Elementor_MCP_Data {
+			public function __construct() {} // skip parent constructor
+
+			public function get_page_data( int $post_id ): array {
+				return array(
+					array(
+						'id'       => 'parent01',
+						'elType'   => 'e-flexbox',
+						'settings' => array(),
+						'elements' => array(
+							array(
+								'id'         => 'child01',
+								'elType'     => 'widget',
+								'widgetType' => 'e-heading',
+								'settings'   => array(),
+								'elements'   => array(),
+							),
+						),
+					),
+				);
+			}
+
+			public function save_page_data( int $post_id, array $data ): bool {
+				return true; // a bool arg from the ability would TypeError here
+			}
+		};
+	}
+
+	public function test_add_atomic_widget_into_parent_saves_array_not_bool(): void {
+		$ability = new \Elementor_MCP_Atomic_Widget_Abilities( $this->make_nested_page_stub(), $this->make_factory() );
+
+		$result = $ability->execute_add_atomic_widget( array(
+			'post_id'     => 42,
+			'parent_id'   => 'parent01',
+			'widget_type' => 'e-heading',
+			'settings'    => array(),
+		) );
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertResultHasKey( $result, 'element_id' );
+	}
+
+	public function test_update_atomic_widget_saves_array_not_bool(): void {
+		$ability = new \Elementor_MCP_Atomic_Widget_Abilities( $this->make_nested_page_stub(), $this->make_factory() );
+
+		$result = $ability->execute_update_atomic_widget( array(
+			'post_id'    => 42,
+			'element_id' => 'child01',
+			'settings'   => array( 'title' => array( '$$type' => 'string', 'value' => 'Hi' ) ),
+		) );
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+	}
+
+	public function test_add_flexbox_into_parent_saves_array_not_bool(): void {
+		$ability = new \Elementor_MCP_Atomic_Layout_Abilities( $this->make_nested_page_stub(), $this->make_factory() );
+
+		$result = $ability->execute_add_flexbox( array(
+			'post_id'   => 42,
+			'parent_id' => 'parent01', // nested -> insert_element() returns bool
+		) );
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertResultHasKey( $result, 'element_id' );
+	}
+}


### PR DESCRIPTION
## Problem
Three atomic ability methods build the element, mutate the page-data array **by reference** through a bool-returning helper, then pass that **bool** to `save_page_data()` — which is typed `array $data`:

| tool | helper (returns `bool`, mutates by-ref) | buggy arg |
|---|---|---|
| `add-atomic-widget` | `insert_element()` | `$inserted` |
| `update-atomic-widget` | `update_element_settings()` | `$updated` |
| `add-flexbox` / `add-div-block` | `insert_element()` (nested branch) | `$inserted` |

Result: a `TypeError` — `Argument #2 ($data) must be of type array, bool given`.

`add-atomic-widget` / `update-atomic-widget` were broken outright. `add-flexbox` / `add-div-block` only broke when `parent_id` was **non-empty** (nested insert) — the top-level branch assigns the array to `$inserted`, which masked the bug for top-level inserts. This was hit live building an atomic page: top-level flexboxes saved, but any nested atomic widget threw.

## Fix
Pass `$page_data` (the array the helper mutated by reference) at all three save sites. One line each.

## Test
`tests/unit/regression/AtomicSaveRegressionTest.php` drives the nested-parent branch for each of the three tools and asserts a normal result array. Reverting any fix reproduces the exact `TypeError` (the data stub keeps the real `array $data` type hint as the guard). Also registers the atomic ability + `Elementor_MCP_Atomic_Styles` classes in the test autoload map.

3/3 new tests pass; rest of the suite unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)