### PR TITLE
feat: atomic text widgets accept styling + typography props

### DIFF
--- a/includes/abilities/class-atomic-layout-abilities.php
+++ b/includes/abilities/class-atomic-layout-abilities.php
@@ -279,7 +279,11 @@ class Elementor_MCP_Atomic_Layout_Abilities {
 			return $inserted;
 		}
 
-		$save = $this->data->save_page_data( $post_id, $inserted );
+		// In the nested-insert branch above, insert_element() returns a bool and
+		// mutates $page_data by reference; only the top-level branch sets
+		// $inserted to the array. Save $page_data so a nested add-flexbox /
+		// add-div-block (non-empty parent_id) doesn't hit a TypeError.
+		$save = $this->data->save_page_data( $post_id, $page_data );
 		if ( is_wp_error( $save ) ) {
 			return $save;
 		}

--- a/includes/abilities/class-atomic-widget-abilities.php
+++ b/includes/abilities/class-atomic-widget-abilities.php
@@ -45,6 +45,30 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 	}
 
 	/**
+	 * JSON-Schema fragment for the flat atomic styling props the factory reads
+	 * (typography + common). Shared by the convenience tools and add-atomic-widget
+	 * so agents discover the capability. The factory accepts more keys than are
+	 * documented here (per-side padding, units); these are the common ones.
+	 *
+	 * @return array<string,array> Schema properties to merge into a tool's input.
+	 */
+	private static function style_schema_props(): array {
+		return array(
+			'font_size'        => array( 'type' => 'number', 'description' => __( 'Font size value (default unit px).', 'elementor-mcp' ) ),
+			'font_size_unit'   => array( 'type' => 'string', 'description' => __( 'Font size unit: px, em, rem.', 'elementor-mcp' ) ),
+			'font_family'      => array( 'type' => 'string', 'description' => __( 'Font family name.', 'elementor-mcp' ) ),
+			'font_weight'      => array( 'type' => 'string', 'description' => __( 'Font weight (e.g. 400, 700).', 'elementor-mcp' ) ),
+			'line_height'      => array( 'type' => 'number', 'description' => __( 'Line height value (default unit em).', 'elementor-mcp' ) ),
+			'letter_spacing'   => array( 'type' => 'number', 'description' => __( 'Letter spacing value (default unit px).', 'elementor-mcp' ) ),
+			'text_align'       => array( 'type' => 'string', 'description' => __( 'Text alignment: left, center, right, justify.', 'elementor-mcp' ) ),
+			'color'            => array( 'type' => 'string', 'description' => __( 'Text color (hex/rgb).', 'elementor-mcp' ) ),
+			'background_color' => array( 'type' => 'string', 'description' => __( 'Background color (hex/rgb).', 'elementor-mcp' ) ),
+			'padding'          => array( 'type' => 'number', 'description' => __( 'Uniform padding value.', 'elementor-mcp' ) ),
+			'border_radius'    => array( 'type' => 'number', 'description' => __( 'Border radius value.', 'elementor-mcp' ) ),
+		);
+	}
+
+	/**
 	 * Registers all atomic widget abilities.
 	 *
 	 * Skips registration entirely if Elementor < 4.0.
@@ -105,12 +129,15 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 				'permission_callback' => array( $this, 'check_edit_permission' ),
 				'input_schema'        => array(
 					'type'       => 'object',
-					'properties' => array(
-						'post_id'     => array( 'type' => 'integer', 'description' => __( 'The post/page ID.', 'elementor-mcp' ) ),
-						'parent_id'   => array( 'type' => 'string', 'description' => __( 'Parent container element ID.', 'elementor-mcp' ) ),
-						'position'    => array( 'type' => 'integer', 'description' => __( 'Insert position. -1 = append.', 'elementor-mcp' ) ),
-						'widget_type' => array( 'type' => 'string', 'description' => __( 'Atomic widget type name (e.g. e-heading, e-button).', 'elementor-mcp' ) ),
-						'settings'    => array( 'type' => 'object', 'description' => __( 'Widget settings with $$type-wrapped values.', 'elementor-mcp' ) ),
+					'properties' => array_merge(
+						array(
+							'post_id'     => array( 'type' => 'integer', 'description' => __( 'The post/page ID.', 'elementor-mcp' ) ),
+							'parent_id'   => array( 'type' => 'string', 'description' => __( 'Parent container element ID.', 'elementor-mcp' ) ),
+							'position'    => array( 'type' => 'integer', 'description' => __( 'Insert position. -1 = append.', 'elementor-mcp' ) ),
+							'widget_type' => array( 'type' => 'string', 'description' => __( 'Atomic widget type name (e.g. e-heading, e-button).', 'elementor-mcp' ) ),
+							'settings'    => array( 'type' => 'object', 'description' => __( 'Widget settings with $$type-wrapped values.', 'elementor-mcp' ) ),
+						),
+						self::style_schema_props()
 					),
 					'required'   => array( 'post_id', 'parent_id', 'widget_type' ),
 				),
@@ -141,7 +168,9 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 			return new \WP_Error( 'missing_widget_type', __( 'widget_type is required.', 'elementor-mcp' ) );
 		}
 
-		$element = $this->factory->create_atomic_widget( $widget_type, $settings );
+		// Flat style props (color, font_size, padding, ...) are read from $input
+		// by the factory's build_common/typography props; unknown keys ignored.
+		$element = $this->factory->create_atomic_widget( $widget_type, $settings, $input );
 
 		$page_data = $this->data->get_page_data( $post_id );
 		if ( is_wp_error( $page_data ) ) {
@@ -254,10 +283,13 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 		$full_name             = 'elementor-mcp/' . $name;
 		$this->ability_names[] = $full_name;
 
-		$base_props = array(
-			'post_id'   => array( 'type' => 'integer', 'description' => __( 'The post/page ID.', 'elementor-mcp' ) ),
-			'parent_id' => array( 'type' => 'string', 'description' => __( 'Parent container element ID (e-flexbox or e-div-block).', 'elementor-mcp' ) ),
-			'position'  => array( 'type' => 'integer', 'description' => __( 'Insert position. -1 = append.', 'elementor-mcp' ) ),
+		$base_props = array_merge(
+			array(
+				'post_id'   => array( 'type' => 'integer', 'description' => __( 'The post/page ID.', 'elementor-mcp' ) ),
+				'parent_id' => array( 'type' => 'string', 'description' => __( 'Parent container element ID (e-flexbox or e-div-block).', 'elementor-mcp' ) ),
+				'position'  => array( 'type' => 'integer', 'description' => __( 'Insert position. -1 = append.', 'elementor-mcp' ) ),
+			),
+			self::style_schema_props()
 		);
 
 		$all_required = array_unique( array_merge( array( 'post_id', 'parent_id' ), $required ) );
@@ -270,14 +302,10 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 				'category'            => 'elementor-mcp',
 				'execute_callback'    => function ( $input ) use ( $widget_type, $settings_fn ) {
 					$settings = $settings_fn( $input );
-					$element  = $this->factory->create_atomic_widget( $widget_type, $settings );
-
-					// Apply styles if style params are present.
-					$common_css = Elementor_MCP_Atomic_Styles::build_common_props( $input );
-					if ( ! empty( $common_css ) ) {
-						$style = Elementor_MCP_Atomic_Styles::create_local_class( $element['id'], $common_css );
-						Elementor_MCP_Atomic_Styles::apply_to_element( $element, $style['class_id'], $style['style_def'] );
-					}
+					// Flat style props (color/spacing + typography) are read from $input
+					// by the factory — routes the convenience tools through the same
+					// styled-widget path as add-atomic-widget.
+					$element  = $this->factory->create_atomic_widget( $widget_type, $settings, $input );
 
 					$post_id   = absint( $input['post_id'] ?? 0 );
 					$parent_id = sanitize_text_field( $input['parent_id'] ?? '' );

--- a/includes/abilities/class-atomic-widget-abilities.php
+++ b/includes/abilities/class-atomic-widget-abilities.php
@@ -153,7 +153,10 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 			return $inserted;
 		}
 
-		$save = $this->data->save_page_data( $post_id, $inserted );
+		// insert_element() returns a bool and mutates $page_data by reference.
+		// save_page_data() expects the page-data array — passing $inserted (bool)
+		// here raised a TypeError and broke add-atomic-widget entirely.
+		$save = $this->data->save_page_data( $post_id, $page_data );
 		if ( is_wp_error( $save ) ) {
 			return $save;
 		}
@@ -213,7 +216,10 @@ class Elementor_MCP_Atomic_Widget_Abilities {
 			return $updated;
 		}
 
-		$save = $this->data->save_page_data( $post_id, $updated );
+		// update_element_settings() returns a bool and mutates $page_data by
+		// reference — pass the array, not the bool (same TypeError class as
+		// add-atomic-widget above).
+		$save = $this->data->save_page_data( $post_id, $page_data );
 		if ( is_wp_error( $save ) ) {
 			return $save;
 		}

--- a/includes/class-atomic-styles.php
+++ b/includes/class-atomic-styles.php
@@ -159,6 +159,47 @@ class Elementor_MCP_Atomic_Styles {
 	}
 
 	/**
+	 * Builds typography CSS props from flat params.
+	 *
+	 * Sibling to build_common_props() — covers the text-styling props that
+	 * one (color/spacing) does not. Only keys present in $params produce
+	 * output; unknown keys are ignored.
+	 *
+	 * @param array $params Flat typography params.
+	 * @return array Map of CSS prop name => $$type-wrapped value.
+	 */
+	public static function build_typography_props( array $params ): array {
+		$props = array();
+
+		// size-typed props: input key => [ css prop, default unit ].
+		$size_props = array(
+			'font_size'      => array( 'font-size', 'px' ),
+			'line_height'    => array( 'line-height', 'em' ),
+			'letter_spacing' => array( 'letter-spacing', 'px' ),
+		);
+		foreach ( $size_props as $input_key => $meta ) {
+			if ( isset( $params[ $input_key ] ) ) {
+				$unit              = $params[ $input_key . '_unit' ] ?? $meta[1];
+				$props[ $meta[0] ] = Elementor_MCP_Atomic_Props::size( (float) $params[ $input_key ], $unit );
+			}
+		}
+
+		// string-typed props: input key => css prop.
+		$string_props = array(
+			'font_family' => 'font-family',
+			'font_weight' => 'font-weight',
+			'text_align'  => 'text-align',
+		);
+		foreach ( $string_props as $input_key => $css_prop ) {
+			if ( isset( $params[ $input_key ] ) ) {
+				$props[ $css_prop ] = Elementor_MCP_Atomic_Props::string( (string) $params[ $input_key ] );
+			}
+		}
+
+		return $props;
+	}
+
+	/**
 	 * Applies a local style class to an element structure.
 	 *
 	 * Adds the class to settings.classes and the style definition to the styles map.

--- a/includes/class-atomic-styles.php
+++ b/includes/class-atomic-styles.php
@@ -147,12 +147,24 @@ class Elementor_MCP_Atomic_Styles {
 			$props['padding-inline-end']   = $size_val;
 		}
 
+		// Atomic's CSS engine validates every style prop against its style-schema
+		// and silently drops invalid keys. `background-color` is NOT a valid key —
+		// atomic uses `background` (Background_Prop_Type, shape { color, ... }).
+		// A flat `background-color` was dropped, so every container/button bg fell
+		// back to the atomic default. Emit the valid `background` shape instead.
 		if ( isset( $params['background_color'] ) ) {
-			$props['background-color'] = Elementor_MCP_Atomic_Props::string( $params['background_color'] );
+			$props['background'] = array(
+				'$$type' => 'background',
+				'value'  => array(
+					'color' => array( '$$type' => 'color', 'value' => $params['background_color'] ),
+				),
+			);
 		}
 
+		// `color` is a Color_Prop_Type ($$type: color), not a plain string — a
+		// string value is rejected by the schema and dropped.
 		if ( isset( $params['color'] ) ) {
-			$props['color'] = Elementor_MCP_Atomic_Props::string( $params['color'] );
+			$props['color'] = array( '$$type' => 'color', 'value' => $params['color'] );
 		}
 
 		return $props;

--- a/includes/class-element-factory.php
+++ b/includes/class-element-factory.php
@@ -185,13 +185,15 @@ class Elementor_MCP_Element_Factory {
 	 * @param array  $settings    The widget settings (already $$type-wrapped).
 	 * @return array The atomic widget element structure.
 	 */
-	public function create_atomic_widget( string $widget_type, array $settings = array() ): array {
+	public function create_atomic_widget( string $widget_type, array $settings = array(), array $style_props = array() ): array {
+		$id = Elementor_MCP_Id_Generator::generate();
+
 		if ( ! isset( $settings['classes'] ) ) {
 			$settings['classes'] = Elementor_MCP_Atomic_Props::classes();
 		}
 
-		return array(
-			'id'              => Elementor_MCP_Id_Generator::generate(),
+		$element = array(
+			'id'              => $id,
 			'elType'          => 'widget',
 			'widgetType'      => $widget_type,
 			'isInner'         => false,
@@ -202,6 +204,18 @@ class Elementor_MCP_Element_Factory {
 			'editor_settings' => array(),
 			'version'         => defined( 'ELEMENTOR_VERSION' ) ? ELEMENTOR_VERSION : '',
 		);
+
+		// Build and apply widget styles if provided (mirrors create_flexbox).
+		$common_css = Elementor_MCP_Atomic_Styles::build_common_props( $style_props );
+		$typo_css   = Elementor_MCP_Atomic_Styles::build_typography_props( $style_props );
+		$all_css    = array_merge( $common_css, $typo_css );
+
+		if ( ! empty( $all_css ) ) {
+			$style = Elementor_MCP_Atomic_Styles::create_local_class( $id, $all_css );
+			Elementor_MCP_Atomic_Styles::apply_to_element( $element, $style['class_id'], $style['style_def'] );
+		}
+
+		return $element;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -594,6 +594,7 @@ namespace {
 		$map = [
 			// Core classes
 			'Elementor_MCP_Atomic_Props'           => 'includes/class-atomic-props.php',
+			'Elementor_MCP_Atomic_Styles'          => 'includes/class-atomic-styles.php',
 			'Elementor_MCP_Data'                  => 'includes/class-elementor-data.php',
 			'Elementor_MCP_Element_Factory'        => 'includes/class-element-factory.php',
 			'Elementor_MCP_Id_Generator'           => 'includes/class-id-generator.php',
@@ -619,6 +620,8 @@ namespace {
 			'Elementor_MCP_Global_Abilities'       => 'includes/abilities/class-global-abilities.php',
 			'Elementor_MCP_Template_Abilities'     => 'includes/abilities/class-template-abilities.php',
 			'Elementor_MCP_Widget_Abilities'       => 'includes/abilities/class-widget-abilities.php',
+			'Elementor_MCP_Atomic_Widget_Abilities' => 'includes/abilities/class-atomic-widget-abilities.php',
+			'Elementor_MCP_Atomic_Layout_Abilities' => 'includes/abilities/class-atomic-layout-abilities.php',
 		];
 
 		if ( isset( $map[ $class ] ) ) {

--- a/tests/unit/AtomicStylesCommonTest.php
+++ b/tests/unit/AtomicStylesCommonTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Unit tests — Atomic_Styles::build_common_props() color/background shapes.
+ *
+ * Atomic's CSS engine validates style props against its style-schema and drops
+ * invalid keys silently. `color` must be a Color_Prop_Type ($$type: color) and
+ * backgrounds must use the `background` key (Background_Prop_Type shape), NOT a
+ * flat `background-color` string — those were dropped, blanking every container
+ * and button background. These tests lock the valid shapes. Verified live.
+ *
+ * @group unit
+ * @group atomic
+ * @package Elementor_MCP\Tests
+ */
+
+namespace Elementor_MCP\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class AtomicStylesCommonTest extends TestCase {
+
+	public function test_color_is_emitted_as_color_prop_type(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_common_props( [ 'color' => '#0a0a0a' ] );
+		$this->assertArrayHasKey( 'color', $props );
+		$this->assertSame( 'color', $props['color']['$$type'] );
+		$this->assertSame( '#0a0a0a', $props['color']['value'] );
+	}
+
+	public function test_color_is_not_emitted_as_plain_string(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_common_props( [ 'color' => '#fff' ] );
+		$this->assertIsArray( $props['color'], 'color must be a typed prop, not a plain string' );
+	}
+
+	public function test_background_color_emits_background_shape_not_flat_key(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_common_props( [ 'background_color' => '#112233' ] );
+		$this->assertArrayNotHasKey( 'background-color', $props, 'flat background-color is dropped by atomic' );
+		$this->assertArrayHasKey( 'background', $props );
+		$this->assertSame( 'background', $props['background']['$$type'] );
+		$this->assertSame( 'color', $props['background']['value']['color']['$$type'] );
+		$this->assertSame( '#112233', $props['background']['value']['color']['value'] );
+	}
+}

--- a/tests/unit/AtomicStylesTypographyTest.php
+++ b/tests/unit/AtomicStylesTypographyTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Unit tests — Atomic_Styles::build_typography_props().
+ *
+ * @group unit
+ * @group atomic
+ * @package Elementor_MCP\Tests
+ */
+
+namespace Elementor_MCP\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class AtomicStylesTypographyTest extends TestCase {
+
+	public function test_empty_params_produce_no_props(): void {
+		$this->assertSame( [], \Elementor_MCP_Atomic_Styles::build_typography_props( [] ) );
+	}
+
+	public function test_font_size_maps_to_size_prop_with_default_px(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_typography_props( [ 'font_size' => 32 ] );
+		$this->assertArrayHasKey( 'font-size', $props );
+		$this->assertSame( 'size', $props['font-size']['$$type'] );
+		$this->assertSame( 32.0, $props['font-size']['value']['size'] );
+		$this->assertSame( 'px', $props['font-size']['value']['unit'] );
+	}
+
+	public function test_font_size_honors_explicit_unit(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_typography_props( [ 'font_size' => 2, 'font_size_unit' => 'rem' ] );
+		$this->assertSame( 'rem', $props['font-size']['value']['unit'] );
+	}
+
+	public function test_line_height_defaults_to_em(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_typography_props( [ 'line_height' => 1.4 ] );
+		$this->assertSame( 'line-height', array_key_first( $props ) );
+		$this->assertSame( 'em', $props['line-height']['value']['unit'] );
+	}
+
+	public function test_letter_spacing_defaults_to_px(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_typography_props( [ 'letter_spacing' => 1 ] );
+		$this->assertSame( 'px', $props['letter-spacing']['value']['unit'] );
+	}
+
+	public function test_string_props_map_to_string_type(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_typography_props( [
+			'font_family' => 'Rubik',
+			'font_weight' => '700',
+			'text_align'  => 'center',
+		] );
+		$this->assertSame( 'string', $props['font-family']['$$type'] );
+		$this->assertSame( 'Rubik', $props['font-family']['value'] );
+		$this->assertSame( '700', $props['font-weight']['value'] );
+		$this->assertSame( 'center', $props['text-align']['value'] );
+	}
+
+	public function test_unknown_keys_ignored(): void {
+		$props = \Elementor_MCP_Atomic_Styles::build_typography_props( [ 'nonsense' => 1, 'color' => '#fff' ] );
+		$this->assertSame( [], $props );
+	}
+}

--- a/tests/unit/functional/AtomicWidgetStyleFunctionalTest.php
+++ b/tests/unit/functional/AtomicWidgetStyleFunctionalTest.php
@@ -31,4 +31,54 @@ class AtomicWidgetStyleFunctionalTest extends Ability_Test_Case {
 		$this->assertArrayHasKey( 'classes', $el['settings'] );
 		$this->assertNotEmpty( $el['settings']['classes']['value'] );
 	}
+
+	public function test_factory_typography_only_props_still_style_the_widget(): void {
+		// font_size alone (no color/spacing) must produce a styles map — proves
+		// typography is wired, not just the pre-existing common props.
+		$el = $this->make_factory()->create_atomic_widget( 'e-heading', array(), array( 'font_size' => 48 ) );
+		$this->assertNotEmpty( $el['styles'] );
+	}
+
+	/**
+	 * Bare add-atomic-widget (the public executor) must apply flat style props
+	 * from input — covers the end-to-end ability path that the convenience
+	 * closures share.
+	 */
+	private function ability(): \Elementor_MCP_Atomic_Widget_Abilities {
+		$data = new class extends \Elementor_MCP_Data {
+			public function __construct() {}
+			public function get_page_data( int $post_id ): array { return array(); }
+			public function save_page_data( int $post_id, array $data ): bool {
+				$GLOBALS['_saved_page'] = $data; // capture for assertions
+				return true;
+			}
+		};
+		return new \Elementor_MCP_Atomic_Widget_Abilities( $data, $this->make_factory() );
+	}
+
+	public function test_add_atomic_widget_applies_flat_style_props(): void {
+		$GLOBALS['_saved_page'] = null;
+		$res = $this->ability()->execute_add_atomic_widget( array(
+			'post_id'     => 7,
+			'parent_id'   => '', // top-level append
+			'widget_type' => 'e-heading',
+			'settings'    => array(),
+			'color'       => '#0a0a0a',
+			'font_size'   => 40,
+		) );
+		$this->assertNotWPError( $res );
+		$this->assertNotEmpty( $GLOBALS['_saved_page'][0]['styles'], 'saved widget should carry a styles map' );
+	}
+
+	public function test_add_atomic_widget_without_style_props_has_no_styles(): void {
+		$GLOBALS['_saved_page'] = null;
+		$res = $this->ability()->execute_add_atomic_widget( array(
+			'post_id'     => 7,
+			'parent_id'   => '',
+			'widget_type' => 'e-heading',
+			'settings'    => array(),
+		) );
+		$this->assertNotWPError( $res );
+		$this->assertSame( array(), $GLOBALS['_saved_page'][0]['styles'], 'no style props -> empty styles (backward compat)' );
+	}
 }

--- a/tests/unit/functional/AtomicWidgetStyleFunctionalTest.php
+++ b/tests/unit/functional/AtomicWidgetStyleFunctionalTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Functional — atomic widgets carry a styles map when style props are passed.
+ *
+ * @group functional
+ * @group atomic
+ * @package Elementor_MCP\Tests\Functional
+ */
+
+namespace Elementor_MCP\Tests\Functional;
+
+require_once dirname( __DIR__ ) . '/class-ability-test-case.php';
+
+use Elementor_MCP\Tests\Ability_Test_Case;
+
+class AtomicWidgetStyleFunctionalTest extends Ability_Test_Case {
+
+	public function test_factory_widget_without_style_props_has_empty_styles(): void {
+		$el = $this->make_factory()->create_atomic_widget( 'e-heading', array() );
+		$this->assertSame( array(), $el['styles'] );
+	}
+
+	public function test_factory_widget_with_style_props_populates_styles_and_classes(): void {
+		$el = $this->make_factory()->create_atomic_widget(
+			'e-heading',
+			array(),
+			array( 'color' => '#112233', 'font_size' => 40 )
+		);
+		$this->assertNotEmpty( $el['styles'], 'styles map should be populated' );
+		// apply_to_element adds the local class id to settings.classes.
+		$this->assertArrayHasKey( 'classes', $el['settings'] );
+		$this->assertNotEmpty( $el['settings']['classes']['value'] );
+	}
+}

--- a/tests/unit/regression/AtomicSaveRegressionTest.php
+++ b/tests/unit/regression/AtomicSaveRegressionTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Regression — atomic save path must pass the page-data array, not a bool.
+ *
+ * Three atomic ability methods built the element, mutated the page-data array
+ * by reference via a bool-returning helper, then passed that bool to
+ * save_page_data():
+ *
+ *   - execute_add_atomic_widget()    -> insert_element() returns bool
+ *   - execute_update_atomic_widget() -> update_element_settings() returns bool
+ *   - execute_add_flexbox/div_block() -> insert_element() returns bool in the
+ *                                        nested-parent branch
+ *
+ * save_page_data() is typed `array $data`, so passing the bool raised a
+ * TypeError and broke the tool. The top-level add-flexbox path happened to set
+ * the var to the array, which is why a top-level flexbox "worked" while a
+ * nested one (non-empty parent_id) blew up.
+ *
+ * Each test drives the nested branch (a real parent element exists in the page)
+ * so the helper returns a bool, and asserts the call returns the normal result
+ * array instead of throwing. The data stub's `array $data` parameter is the
+ * guard: a bool would TypeError before any assertion runs.
+ *
+ * @group regression
+ * @group atomic
+ * @package Elementor_MCP\Tests\Regression
+ */
+
+namespace Elementor_MCP\Tests\Regression;
+
+require_once dirname( __DIR__ ) . '/class-ability-test-case.php';
+
+use Elementor_MCP\Tests\Ability_Test_Case;
+
+class AtomicSaveRegressionTest extends Ability_Test_Case {
+
+	/**
+	 * Data stub whose page already contains a parent flexbox with one child
+	 * widget, so nested inserts/updates resolve and the by-ref helpers return a
+	 * bool. save_page_data() keeps the real `array $data` type hint.
+	 */
+	private function make_nested_page_stub(): \Elementor_MCP_Data {
+		return new class extends \Elementor_MCP_Data {
+			public function __construct() {} // skip parent constructor
+
+			public function get_page_data( int $post_id ): array {
+				return array(
+					array(
+						'id'       => 'parent01',
+						'elType'   => 'e-flexbox',
+						'settings' => array(),
+						'elements' => array(
+							array(
+								'id'         => 'child01',
+								'elType'     => 'widget',
+								'widgetType' => 'e-heading',
+								'settings'   => array(),
+								'elements'   => array(),
+							),
+						),
+					),
+				);
+			}
+
+			public function save_page_data( int $post_id, array $data ): bool {
+				return true; // a bool arg from the ability would TypeError here
+			}
+		};
+	}
+
+	public function test_add_atomic_widget_into_parent_saves_array_not_bool(): void {
+		$ability = new \Elementor_MCP_Atomic_Widget_Abilities( $this->make_nested_page_stub(), $this->make_factory() );
+
+		$result = $ability->execute_add_atomic_widget( array(
+			'post_id'     => 42,
+			'parent_id'   => 'parent01',
+			'widget_type' => 'e-heading',
+			'settings'    => array(),
+		) );
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertResultHasKey( $result, 'element_id' );
+	}
+
+	public function test_update_atomic_widget_saves_array_not_bool(): void {
+		$ability = new \Elementor_MCP_Atomic_Widget_Abilities( $this->make_nested_page_stub(), $this->make_factory() );
+
+		$result = $ability->execute_update_atomic_widget( array(
+			'post_id'    => 42,
+			'element_id' => 'child01',
+			'settings'   => array( 'title' => array( '$$type' => 'string', 'value' => 'Hi' ) ),
+		) );
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+	}
+
+	public function test_add_flexbox_into_parent_saves_array_not_bool(): void {
+		$ability = new \Elementor_MCP_Atomic_Layout_Abilities( $this->make_nested_page_stub(), $this->make_factory() );
+
+		$result = $ability->execute_add_flexbox( array(
+			'post_id'   => 42,
+			'parent_id' => 'parent01', // nested -> insert_element() returns bool
+		) );
+
+		$this->assertNotWPError( $result );
+		$this->assertIsArray( $result );
+		$this->assertResultHasKey( $result, 'element_id' );
+	}
+}


### PR DESCRIPTION
## What
Makes the atomic (V4) text widgets actually styleable through MCP.

- **New** `Atomic_Styles::build_typography_props()` — `font_size/font_family/font_weight/line_height/letter_spacing/text_align` → atomic typed CSS props (sibling to `build_common_props`, which covers color/spacing only).
- `create_atomic_widget()` gains an optional `$style_props` arg and applies a local style class exactly like `create_flexbox` (common + typography).
- `add-atomic-heading/paragraph/button` and the bare `add-atomic-widget` now route flat style props from input through that path — so they apply **typography** on top of the color/spacing the convenience tools already handled.
- A shared `style_schema_props()` documents the common props in each tool's `input_schema` so agents discover the capability.

## Why
Before this, atomic widgets could set content + color/spacing but **no typography** — building a real atomic page produced default-styled text (e.g. dark heading on a dark section = invisible). Found while building an atomic page end-to-end via MCP.

## Backward compatible
No style props → empty `styles` map, identical to today. The third `create_atomic_widget` arg defaults to `[]`.

## Tests
- `AtomicStylesTypographyTest` (7) — each typography key → correct CSS prop + `$$type` wrapper + units; unknown keys ignored.
- `AtomicWidgetStyleFunctionalTest` (5) — factory applies styles only when props passed; typography-only props still style; bare `add-atomic-widget` applies flat style props end-to-end; no props → empty styles (backward-compat guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)