### PR TITLE
Fix: boot autoloaded MCP adapter so the endpoint isn't gated by WooCommerce's MCP flag

### DIFF
--- a/includes/class-mcp-adapter-bootstrap.php
+++ b/includes/class-mcp-adapter-bootstrap.php
@@ -53,9 +53,28 @@ final class EMCP_Tools_Adapter_Bootstrap {
 	 * @since 1.7.4
 	 */
 	public static function ensure(): void {
-		// A standalone MCP Adapter plugin is already active — defer to it.
+		// A copy of the MCP Adapter is already loadable. That can be a standalone
+		// MCP Adapter plugin (which boots it) OR another plugin that merely bundles
+		// and autoloads the WP\MCP classes without booting a server. WooCommerce
+		// 10.5+ does the latter: it registers the WP\MCP autoloader (so the
+		// class_exists() check below is true) but only instantiates the adapter
+		// when its experimental "MCP Integration" feature flag is enabled, which is
+		// off by default. "Loadable" is not "booted": if nobody boots the adapter,
+		// mcp_adapter_init never fires, our MCP server route is never created, and
+		// the endpoint 404s. So ensure the adapter is booted instead of deferring
+		// to a no-op.
 		if ( class_exists( '\WP\MCP\Core\McpAdapter' ) ) {
 			self::$source = 'external';
+
+			// Idempotent singleton: a no-op if the external owner already booted
+			// the adapter, and the safety net when it only autoloaded the classes
+			// (e.g. WooCommerce with its MCP feature flag off). This only fires
+			// mcp_adapter_init; it does not register any other plugin's tools —
+			// those are added on that hook by each plugin's own (gated) code.
+			if ( class_exists( '\WP\MCP\Plugin' ) ) {
+				\WP\MCP\Plugin::instance();
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
## What

`EMCP_Tools_Adapter_Bootstrap::ensure()` deferred to *any* already-loadable
`\WP\MCP\Core\McpAdapter` and `return`ed without booting it, assuming an external
owner (a standalone MCP Adapter plugin) would boot the adapter and fire
`mcp_adapter_init`.

**WooCommerce 10.5+ breaks that assumption.** It bundles `wordpress/mcp-adapter`
and registers the `WP\MCP` autoloader (so `class_exists()` is `true`), but only
*instantiates* the adapter when its experimental **"MCP Integration"** feature
flag is on — and that flag is **off by default**. Result: nobody boots the
adapter, `mcp_adapter_init` never fires, `register_mcp_server()` (hooked at
priority 20) never runs, `create_server()` is never called, and the MCP endpoint
(`/wp-json/mcp/emcp-tools-server`) returns **404**.

Turning on an unrelated WooCommerce feature should not be a prerequisite for
EMCP's own endpoint to exist.

## Change

In the defer branch, boot the already-loaded adapter via the idempotent
`\WP\MCP\Plugin::instance()` singleton:

- **No-op** when the external owner already booted the adapter (a standalone MCP
  Adapter plugin, or WooCommerce with its flag on).
- **Safety net** when the classes were only autoloaded (WooCommerce with its
  flag off) — EMCP boots the adapter itself so `mcp_adapter_init` fires and its
  server registers.

## Why it's safe

- `\WP\MCP\Plugin::instance()` / `McpAdapter::instance()` are singletons, so
  calling `instance()` again returns the existing instance without re-wiring hooks.
- Booting the adapter core only fires `mcp_adapter_init`. It does **not** register
  WooCommerce's own MCP tools: WooCommerce adds its `mcp_adapter_init` listener
  only when its feature flag is on, so merely firing the action exposes nothing of
  WooCommerce's. Only consumers that explicitly registered a server (here, EMCP's
  own `register_mcp_server`) create routes.
- EMCP's existing "Activate Abilities API for EMCP" gate still governs whether the
  server is created.

## Testing

Reproduced on WordPress 6.9 / PHP 8.1 / WooCommerce 10.5+ with EMCP Tools 3.0.0
and the "MCP Integration" flag off: `/wp-json/mcp/emcp-tools-server` 404s before
this change; enabling the WooCommerce flag was the only prior workaround. With the
patch, the endpoint is served regardless of the WooCommerce flag.

Fixes #64
