### PR TITLE
fix: move-block loses/misplaces the block when removal shifts the target path

### DIFF
--- a/includes/class-block-tree.php
+++ b/includes/class-block-tree.php
@@ -194,14 +194,24 @@ class EMCP_Tools_Block_Tree {
 			return $blocks;
 		}
 
-		// Adjust the target index when source and target share the same parent and
-		// the source sits before the insertion point (removal shifts it left by 1).
-		if ( in_array( $mode, array( 'before', 'after' ), true )
-			&& count( $from ) === count( $to )
-			&& array_slice( $from, 0, -1 ) === array_slice( $to, 0, -1 )
-			&& (int) end( $from ) < (int) end( $to ) ) {
-			$to[ count( $to ) - 1 ] = (int) $to[ count( $to ) - 1 ] - 1;
-			$position['path']       = $to;
+		// A move whose target lies inside the moved node's own subtree would remove the
+		// node and then fail to re-insert it (its path no longer resolves), losing the
+		// block. Reject it as a no-op.
+		$depth = count( $from );
+		if ( count( $to ) >= $depth && array_slice( $to, 0, $depth ) === $from ) {
+			return $blocks;
+		}
+
+		// remove() shifts every later sibling under $from's parent left by one. When the
+		// target path passes through that parent at a position after $from, the index there
+		// is now stale — decrement it so insert() still lands correctly. Applies to every
+		// mode (before/after siblings AND inside a later container) at any depth.
+		$shift = $depth - 1;
+		if ( count( $to ) > $shift
+			&& array_slice( $from, 0, $shift ) === array_slice( $to, 0, $shift )
+			&& (int) $to[ $shift ] > (int) $from[ $shift ] ) {
+			$to[ $shift ]     = (int) $to[ $shift ] - 1;
+			$position['path'] = $to;
 		}
 
 		$without = self::remove( $blocks, $from );


### PR DESCRIPTION
Fixes #67.

`move-block` (`EMCP_Tools_Block_Tree::move()`) is remove-then-insert. Removing the source shifts the indices of every later sibling, but the existing compensation only covers **same-parent, same-depth** `before`/`after` moves. For `mode: "inside"` and cross-level targets the insert path is stale, so `edit_siblings()` returns the tree unchanged and the removed block is **never re-inserted** — silent data loss, while the tool still reports success. (With a block after the target, the node lands in the wrong container instead.)

Repro: three top-level blocks `[A, B, group]`; `move-block { "path":[0], "position":{ "mode":"inside", "path":[2] } }` deletes A from the post.

This PR:

- **Generalizes** the index-shift compensation to every mode and depth. The old same-parent `before`/`after` case is a strict subset of the new condition, so that path's behavior is unchanged.
- **Rejects** a move whose target is inside the moved node's own subtree (that path also removed-then-lost the node) as a no-op.

Pure `parse_blocks` / `serialize_blocks` logic — no Elementor or PHP-version specifics.
