### PR TITLE
feat(connection): opt-in URL-based authentication for the MCP server route

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ Add to `~/.gemini/antigravity/mcp_config.json`:
 }
 ```
 
+### Claude.ai (web custom connector)
+
+Claude.ai's custom connectors only take a server URL — there's no field for an `Authorization` header, and the connection is made from Anthropic's cloud rather than your browser, so there's no local client to add one either. Turn on **URL-based authentication** on the Connection tab (off by default), then use the endpoint with your credentials appended as a query parameter:
+
+1. Go to **Profile → Settings → Integrations** on claude.ai and add a custom connector.
+2. Use this as the server URL, replacing `BASE64_ENCODED_CREDENTIALS` with your base64-encoded `username:app-password`:
+
+```text
+https://your-site.com/wp-json/mcp/emcp-tools-server?emcp_auth=BASE64_ENCODED_CREDENTIALS
+```
+
+The Connection tab generates this URL for you automatically once the toggle is on.
+
 ### WP-CLI stdio (local development)
 
 For local development with WP-CLI available, you can use the stdio transport (no HTTP auth needed):

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -410,6 +410,17 @@
 				authRow.style.display = '';
 			}
 
+			// URL-based authentication (only rendered when the toggle is on).
+			var urlAuthRow = document.getElementById( 'elementor-mcp-urlauth-result-row' );
+			var urlAuthCode = document.getElementById( 'elementor-mcp-urlauth-result' );
+			var urlAuthCopy = document.getElementById( 'elementor-mcp-urlauth-result-copy' );
+			if ( urlAuthRow && urlAuthCode && urlAuthCopy && typeof emcpToolsAdmin !== 'undefined' && emcpToolsAdmin.mcpEndpoint ) {
+				var urlAuthValue = emcpToolsAdmin.mcpEndpoint + '?emcp_auth=' + encodeURIComponent( btoa( rawUsername + ':' + rawAppPassword ) );
+				urlAuthRow.style.display = '';
+				urlAuthCode.textContent = urlAuthValue;
+				urlAuthCopy.value = urlAuthValue;
+			}
+
 			if ( typeof emcpToolsAdmin === 'undefined' || ! emcpToolsAdmin.mcpEndpoint ) {
 				return;
 			}

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -725,6 +725,22 @@ class EMCP_Tools_Admin {
 			)
 		);
 
+		// URL-based authentication for the MCP server route (Connection tab). OFF
+		// by default — Base64 credentials in a URL query string can end up in
+		// server access logs, browser history, or a Referer header, so it's an
+		// explicit opt-in fallback for hosts that strip the Authorization header.
+		register_setting(
+			self::SETTINGS_GROUP_SERVER,
+			EMCP_Tools_Url_Auth::OPTION_ENABLED,
+			array(
+				'type'              => 'string',
+				'default'           => '0',
+				'sanitize_callback' => static function ( $value ) {
+					return '1' === (string) $value ? '1' : '0';
+				},
+			)
+		);
+
 		// Stock-image provider API keys (Connection → 3rd Party Services sub-tab)
 		// — power the stock-image tools (search-images / add-stock-image). All
 		// three are free keys. Registered in their own group so that sub-tab's

--- a/includes/admin/views/page-connection.php
+++ b/includes/admin/views/page-connection.php
@@ -127,6 +127,8 @@ $emcp_tools_server_enabled = class_exists( 'EMCP_Tools_Plugin' )
 			</div>
 		</div>
 
+		<?php $emcp_tools_url_auth_enabled = EMCP_Tools_Url_Auth::is_enabled(); ?>
+
 		<form method="post" action="options.php" id="emcp-conn-form" class="elementor-mcp-activate-form">
 			<?php settings_fields( EMCP_Tools_Admin::SETTINGS_GROUP_SERVER ); ?>
 
@@ -195,6 +197,44 @@ $emcp_tools_server_enabled = class_exists( 'EMCP_Tools_Plugin' )
 						);
 						?>
 					</p>
+				</div>
+
+				<?php // Card C: URL-based authentication. ?>
+				<div class="emcp-conn-card">
+					<h2 class="emcp-conn-card-title"><?php esc_html_e( 'URL-based authentication', 'emcp-tools' ); ?></h2>
+
+					<label class="emcp-switch emcp-conn-toggle">
+						<input
+							type="checkbox"
+							name="<?php echo esc_attr( EMCP_Tools_Url_Auth::OPTION_ENABLED ); ?>"
+							value="1"
+							<?php checked( $emcp_tools_url_auth_enabled ); ?>
+						/>
+						<span class="elementor-mcp-toggle" aria-hidden="true"><span class="elementor-mcp-toggle-track"></span></span>
+						<span class="emcp-switch-label"><?php esc_html_e( 'Also accept credentials via a URL query parameter', 'emcp-tools' ); ?></span>
+					</label>
+
+					<p class="elementor-mcp-activate-note">
+						<?php esc_html_e( 'Adds an additional authentication method alongside the Authorization header: the same Base64 "username:application_password" value, passed as an emcp_auth query parameter on the MCP endpoint URL. Useful when a host strips the Authorization header before it reaches PHP (see the troubleshooting box below) and fixing that at the server level is not an option. Still only ever validates Application Passwords — never a regular account password.', 'emcp-tools' ); ?>
+					</p>
+					<p class="elementor-mcp-activate-note elementor-mcp-activate-note--security">
+						<strong><?php esc_html_e( 'Security note:', 'emcp-tools' ); ?></strong>
+						<?php esc_html_e( 'Credentials embedded in a URL can end up in server access logs, browser history, or a Referer header. Leave this off unless you specifically need it, and prefer the Authorization header when your host supports it.', 'emcp-tools' ); ?>
+					</p>
+
+					<?php if ( $emcp_tools_url_auth_enabled ) : ?>
+						<div id="elementor-mcp-urlauth-result-row" style="display: none;">
+							<div class="elementor-mcp-cred-field">
+								<label for="elementor-mcp-urlauth-result-copy"><?php esc_html_e( 'MCP endpoint URL (with embedded credentials)', 'emcp-tools' ); ?></label>
+								<div class="elementor-mcp-auth-result">
+									<code id="elementor-mcp-urlauth-result"></code>
+									<button type="button" class="button elementor-mcp-copy-btn" data-target="elementor-mcp-urlauth-result-copy"><?php esc_html_e( 'Copy', 'emcp-tools' ); ?></button>
+									<textarea id="elementor-mcp-urlauth-result-copy" class="elementor-mcp-copy-source"></textarea>
+								</div>
+								<p class="description"><?php esc_html_e( 'Generate credentials in Step 1 below to fill this in.', 'emcp-tools' ); ?></p>
+							</div>
+						</div>
+					<?php endif; ?>
 				</div>
 
 			</div>

--- a/includes/class-bootstrap.php
+++ b/includes/class-bootstrap.php
@@ -80,6 +80,7 @@ class EMCP_Tools_Bootstrap {
 		require_once EMCP_TOOLS_DIR . 'includes/class-schema-compat.php';
 		require_once EMCP_TOOLS_DIR . 'includes/class-id-generator.php';
 		require_once EMCP_TOOLS_DIR . 'includes/class-url-guard.php';
+		require_once EMCP_TOOLS_DIR . 'includes/class-url-auth.php';
 		require_once EMCP_TOOLS_DIR . 'includes/class-site-context.php';
 		require_once EMCP_TOOLS_DIR . 'includes/class-elementor-data.php';
 		require_once EMCP_TOOLS_DIR . 'includes/class-element-factory.php';
@@ -249,6 +250,11 @@ class EMCP_Tools_Bootstrap {
 		// Admin-bar MCP status + exposure toggle (front-end + wp-admin; the class
 		// self-gates on capability + is_admin_bar_showing()).
 		( new EMCP_Tools_Admin_Bar() )->init();
+
+		// URL-based authentication for the MCP server route (opt-in — Connection
+		// tab). Accepts Base64 "user:app_password" via a query parameter as a
+		// fallback when a host strips the Authorization header.
+		( new EMCP_Tools_Url_Auth() )->init();
 
 		// Free-tier updates from GitHub releases (self-disables on premium builds,
 		// where Freemius owns updates).

--- a/includes/class-url-auth.php
+++ b/includes/class-url-auth.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * URL-based authentication for the EMCP MCP server endpoint.
+ *
+ * Some hosts (Apache/Plesk/LiteSpeed/IIS configs — see the Connection tab's
+ * "Got 401 Unauthorized?" troubleshooting) strip the Authorization header
+ * before it reaches PHP, which breaks the standard Basic-auth Application
+ * Password flow entirely. This class adds an additional, opt-in authentication
+ * method: the same "username:application_password" credentials, Base64-encoded
+ * and passed as a URL query parameter, so a client can authenticate even when
+ * the Authorization header never arrives. It only ever validates Application
+ * Passwords (via the same core function core's Basic-auth handler uses) — a
+ * regular account password will never work here.
+ *
+ * Off by default: credentials in a URL can end up in server access logs,
+ * browser history, or a Referer header, so the admin must opt in on the
+ * Connection tab.
+ *
+ * @package EMCP_Tools
+ * @since   3.2.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Authenticates MCP server requests using Base64 "user:app_password"
+ * credentials supplied via a URL query parameter.
+ *
+ * @since 3.2.0
+ */
+class EMCP_Tools_Url_Auth {
+
+	/**
+	 * Option name for the opt-in toggle (Connection tab).
+	 *
+	 * @since 3.2.0
+	 */
+	const OPTION_ENABLED = 'emcp_tools_url_auth_enabled';
+
+	/**
+	 * Query parameter name carrying the Base64-encoded credentials. Accepts
+	 * either a bare Base64 token or a "Basic <token>" value (mirrors the
+	 * Authorization header format, so the same generated value works in both
+	 * places).
+	 *
+	 * @since 3.2.0
+	 */
+	const PARAM = 'emcp_auth';
+
+	/**
+	 * Registers the authentication filter.
+	 *
+	 * @since 3.2.0
+	 */
+	public function init(): void {
+		// Priority 15: after plugins that populate PHP_AUTH_* from other means,
+		// before nothing in particular — we only act when no user is resolved
+		// yet and defer entirely otherwise.
+		add_filter( 'determine_current_user', array( $this, 'authenticate' ), 15 );
+	}
+
+	/**
+	 * Whether URL-based authentication is enabled.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled(): bool {
+		return '1' === (string) get_option( self::OPTION_ENABLED, '0' );
+	}
+
+	/**
+	 * `determine_current_user` callback. Resolves a WordPress user ID from
+	 * Base64 "username:application_password" credentials in the request's
+	 * `emcp_auth` query parameter, scoped to the EMCP MCP server route.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @param int|bool $user Existing resolved user (from an earlier filter), or false/empty.
+	 * @return int|bool The authenticated user ID, or the passed-through value.
+	 */
+	public function authenticate( $user ) {
+		// Don't override an already-resolved user (cookie auth, Basic auth, etc.).
+		if ( ! empty( $user ) ) {
+			return $user;
+		}
+
+		if ( ! self::is_enabled() ) {
+			return $user;
+		}
+
+		if ( ! $this->is_mcp_server_request() ) {
+			return $user;
+		}
+
+		$credentials = $this->extract_credentials();
+		if ( null === $credentials ) {
+			return $user;
+		}
+
+		list( $username, $password ) = $credentials;
+		if ( '' === $username || '' === $password ) {
+			return $user;
+		}
+
+		if ( ! function_exists( 'wp_authenticate_application_password' ) ) {
+			return $user;
+		}
+
+		$authenticated = wp_authenticate_application_password( null, $username, $password );
+
+		if ( $authenticated instanceof WP_User ) {
+			return $authenticated->ID;
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Whether the current request targets the EMCP MCP server route. Matches
+	 * both pretty-permalink (`/wp-json/mcp/emcp-tools-server`) and plain
+	 * (`?rest_route=/mcp/emcp-tools-server`) request URIs.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return bool
+	 */
+	private function is_mcp_server_request(): bool {
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read-only substring match, not used as output or a filesystem/SQL value.
+		$uri = (string) $_SERVER['REQUEST_URI'];
+
+		return false !== strpos( $uri, 'mcp/emcp-tools-server' );
+	}
+
+	/**
+	 * Extracts and decodes the `username`/`application password` pair from the
+	 * `emcp_auth` query parameter.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return array{0:string,1:string}|null Two-element [username, password] array, or null if absent/malformed.
+	 */
+	private function extract_credentials(): ?array {
+		if ( empty( $_GET[ self::PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- an auth credential, not a nonce-protected action.
+			return null;
+		}
+
+		$raw = sanitize_text_field( wp_unslash( $_GET[ self::PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$raw = trim( (string) preg_replace( '/^Basic\s+/i', '', trim( $raw ) ) );
+
+		if ( '' === $raw ) {
+			return null;
+		}
+
+		$decoded = base64_decode( $raw, true );
+		if ( false === $decoded || false === strpos( $decoded, ':' ) ) {
+			return null;
+		}
+
+		$parts = explode( ':', $decoded, 2 );
+
+		return array( (string) $parts[0], (string) $parts[1] );
+	}
+}

--- a/mcp-config-examples.json
+++ b/mcp-config-examples.json
@@ -97,6 +97,12 @@
     }
   },
 
+  "claude_ai_custom_connector": {
+    "_description": "Claude.ai (web) — custom connector using URL-based authentication",
+    "_note": "Claude.ai's custom connector UI only accepts a server URL, with no field for an Authorization header, and the connection runs from Anthropic's cloud so there's no local client to add one either. Enable 'URL-based authentication' on the Connection tab first (off by default), then use this URL as the connector's server URL.",
+    "url": "https://your-site.com/wp-json/mcp/emcp-tools-server?emcp_auth=BASE64_OF_USERNAME:APP_PASSWORD"
+  },
+
   "vscode_mcp_direct_http": {
     "_description": "VS Code MCP extension — direct HTTP connection (add to VS Code settings)",
     "servers": {


### PR DESCRIPTION
Adds a second authentication method for the `emcp-tools-server` MCP route:
the same Base64 `username:application_password` credentials normally sent
in the `Authorization: Basic ...` header can now also be passed via an
`emcp_auth` query parameter on the endpoint URL.

Claude.ai's custom connectors only accept a server URL — there's no field
for a Basic Auth header, and the connection is made from Anthropic's cloud,
so there's no local client to inject one either. That's made it impossible
to connect this MCP server to Claude.ai until now. With credentials
embeddable in the URL itself, a user can paste
`https://your-site.com/wp-json/mcp/emcp-tools-server?emcp_auth=<base64>`
directly into Claude.ai's connector field and it works. It also helps hosts
that strip the `Authorization` header before it reaches PHP.

`EMCP_Tools_Url_Auth` hooks `determine_current_user`, scoped to the
`mcp/emcp-tools-server` route, decodes `emcp_auth`, and validates it through
core's own `wp_authenticate_application_password()` — the same check the
header path already uses, Application Passwords only. Off by default — new
`emcp_tools_url_auth_enabled` option on the Connection tab, which also gets
a toggle and a ready-to-copy URL once enabled.
