### PR TITLE
fix(content): honor protected-meta allowlist in get-post reader

### DIFF
--- a/includes/abilities/class-content-abilities.php
+++ b/includes/abilities/class-content-abilities.php
@@ -582,8 +582,10 @@ class EMCP_Tools_Content_Abilities {
 		$meta_raw = get_post_meta( $post_id );
 		$meta     = array();
 		if ( is_array( $meta_raw ) ) {
+			$allowed = (array) apply_filters( 'emcp_tools_content_allowed_protected_meta', array() );
 			foreach ( $meta_raw as $key => $vals ) {
-				if ( '_' === substr( (string) $key, 0, 1 ) || is_protected_meta( (string) $key, 'post' ) ) {
+				$key = (string) $key;
+				if ( ! in_array( $key, $allowed, true ) && ( '_' === substr( $key, 0, 1 ) || is_protected_meta( $key, 'post' ) ) ) {
 					continue;
 				}
 				$meta[ $key ] = is_array( $vals ) && 1 === count( $vals ) ? maybe_unserialize( $vals[0] ) : array_map( 'maybe_unserialize', (array) $vals );


### PR DESCRIPTION
# PR: get-post honours the protected-meta write allowlist on read

**Branch:** `fix/get-post-honor-protected-meta-allowlist`
**Base:** `main` @ `45ad949` family (content-abilities blob `24759c993271dfd27a156098c5f1f2b33f1e91a1`)
**File:** `includes/abilities/class-content-abilities.php` (+3 / −1)

## Why

`create-post`/`update-post` allow writing protected meta keys that a site opts into via
`apply_filters( 'emcp_tools_content_allowed_protected_meta', [] )`, but the `get-post` reader
hard-codes the `_`-prefix / `is_protected_meta()` hide and never consults that filter — so
allowlisted keys are writable but not readable (broken read-after-write). This makes the reader
honour the same allowlist the writer already does.

## Diff

```diff
@@ build_post_payload() meta reader
 		$meta_raw = get_post_meta( $post_id );
 		$meta     = array();
 		if ( is_array( $meta_raw ) ) {
+			$allowed = (array) apply_filters( 'emcp_tools_content_allowed_protected_meta', array() );
 			foreach ( $meta_raw as $key => $vals ) {
-				if ( '_' === substr( (string) $key, 0, 1 ) || is_protected_meta( (string) $key, 'post' ) ) {
+				$key = (string) $key;
+				if ( ! in_array( $key, $allowed, true ) && ( '_' === substr( $key, 0, 1 ) || is_protected_meta( $key, 'post' ) ) ) {
 					continue;
 				}
 				$meta[ $key ] = is_array( $vals ) && 1 === count( $vals ) ? maybe_unserialize( $vals[0] ) : array_map( 'maybe_unserialize', (array) $vals );
 			}
 		}
```

## Behaviour

- Default (empty allowlist): identical output — every `_`/protected key still hidden.
- With a site opt-in: the same keys `update-post` accepts are now returned by `get-post`.
- Mirrors the exact allowlist logic already in `reject_protected_meta()` (l.284–290).


Closes #77
