### PR TITLE
fix(atomic): correct image/svg envelopes + writable styles/editor_settings (#72, #73, #74)

### DIFF
--- a/includes/abilities/class-atomic-widget-abilities.php
+++ b/includes/abilities/class-atomic-widget-abilities.php
@@ -434,8 +434,7 @@ class EMCP_Tools_Atomic_Widget_Abilities {
 				$image_url = esc_url_raw( $input['image_url'] ?? '' );
 
 				if ( $image_id ) {
-					$url = wp_get_attachment_url( $image_id );
-					$settings['image'] = EMCP_Tools_Atomic_Props::image( $image_id, $url ?: '' );
+					$settings['image'] = EMCP_Tools_Atomic_Props::image( $image_id );
 				} elseif ( $image_url ) {
 					$settings['image'] = EMCP_Tools_Atomic_Props::image( 0, $image_url );
 				}
@@ -475,10 +474,9 @@ class EMCP_Tools_Atomic_Widget_Abilities {
 				$svg_url = esc_url_raw( $input['svg_url'] ?? '' );
 
 				if ( $svg_id ) {
-					$url = wp_get_attachment_url( $svg_id );
-					$settings['svg'] = EMCP_Tools_Atomic_Props::image( $svg_id, $url ?: '' );
+					$settings['svg'] = EMCP_Tools_Atomic_Props::svg( $svg_id );
 				} elseif ( $svg_url ) {
-					$settings['svg'] = EMCP_Tools_Atomic_Props::image( 0, $svg_url );
+					$settings['svg'] = EMCP_Tools_Atomic_Props::svg( 0, $svg_url );
 				}
 
 				if ( ! empty( $input['css_id'] ) ) {

--- a/includes/abilities/class-layout-abilities.php
+++ b/includes/abilities/class-layout-abilities.php
@@ -56,6 +56,7 @@ class EMCP_Tools_Layout_Abilities {
 			'emcp-tools/update-container',
 			'emcp-tools/update-element',
 			'emcp-tools/batch-update',
+			'emcp-tools/set-element-label',
 			'emcp-tools/reorder-elements',
 			'emcp-tools/move-element',
 			'emcp-tools/remove-element',
@@ -73,6 +74,7 @@ class EMCP_Tools_Layout_Abilities {
 		$this->register_update_container();
 		$this->register_update_element();
 		$this->register_batch_update();
+		$this->register_set_element_label();
 		$this->register_reorder_elements();
 		$this->register_move_element();
 		$this->register_remove_element();
@@ -315,7 +317,7 @@ class EMCP_Tools_Layout_Abilities {
 			'emcp-tools/update-element',
 			array(
 				'label'               => __( 'Update Element', 'emcp-tools' ),
-				'description'         => __( 'Updates settings on any element (container or widget). Settings are merged (partial update). Works for all element types — no need to know if the target is a container or widget.', 'emcp-tools' ),
+				'description'         => __( 'Updates settings on any element (container or widget). Settings are merged (partial update). Works for all element types — no need to know if the target is a container or widget. For v4 atomic elements you may also include a `styles` map (the element\'s local CSS classes) and/or `editor_settings` (e.g. `{ "title": "Hero" }` for the Navigator label) in the settings object — these are routed to the element root automatically. Use set-element-label for just the Navigator name.', 'emcp-tools' ),
 				'category'            => 'emcp-tools',
 				'execute_callback'    => array( $this, 'execute_update_element' ),
 				'permission_callback' => array( $this, 'check_edit_permission' ),
@@ -406,7 +408,7 @@ class EMCP_Tools_Layout_Abilities {
 			'emcp-tools/batch-update',
 			array(
 				'label'               => __( 'Batch Update Elements', 'emcp-tools' ),
-				'description'         => __( 'Updates multiple elements in a single save operation. Each operation specifies an element_id and settings to merge. Much more efficient than calling update-element multiple times.', 'emcp-tools' ),
+				'description'         => __( 'Updates multiple elements in a single save operation. Each operation specifies an element_id and settings to merge. Much more efficient than calling update-element multiple times. As with update-element, a per-operation settings object may include a `styles` map and/or `editor_settings` for v4 atomic elements — these are routed to the element root automatically.', 'emcp-tools' ),
 				'category'            => 'emcp-tools',
 				'execute_callback'    => array( $this, 'execute_batch_update' ),
 				'permission_callback' => array( $this, 'check_edit_permission' ),
@@ -504,6 +506,101 @@ class EMCP_Tools_Layout_Abilities {
 			'success' => empty( $failed ),
 			'updated' => $updated_count,
 			'failed'  => $failed,
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// set-element-label (Navigator label — editor_settings.title)
+	// -------------------------------------------------------------------------
+
+	private function register_set_element_label(): void {
+		emcp_tools_register_ability(
+			'emcp-tools/set-element-label',
+			array(
+				'label'               => __( 'Set Element Label', 'emcp-tools' ),
+				'description'         => __( 'Sets an element\'s Navigator label (stored in editor_settings.title). Works for any element; especially useful on v4 atomic elements to keep the layout readable. A convenience wrapper — the same result can be had via update-element with editor_settings.', 'emcp-tools' ),
+				'category'            => 'emcp-tools',
+				'execute_callback'    => array( $this, 'execute_set_element_label' ),
+				'permission_callback' => array( $this, 'check_edit_permission' ),
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'post_id'    => array(
+							'type'        => 'integer',
+							'description' => __( 'The post/page ID.', 'emcp-tools' ),
+						),
+						'element_id' => array(
+							'type'        => 'string',
+							'description' => __( 'The element ID to label.', 'emcp-tools' ),
+						),
+						'title'      => array(
+							'type'        => 'string',
+							'description' => __( 'The Navigator label to set.', 'emcp-tools' ),
+						),
+					),
+					'required'   => array( 'post_id', 'element_id', 'title' ),
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'element_id' => array( 'type' => 'string' ),
+						'title'      => array( 'type' => 'string' ),
+					),
+				),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	public function execute_set_element_label( $input ) {
+		$post_id    = absint( $input['post_id'] ?? 0 );
+		$element_id = sanitize_text_field( $input['element_id'] ?? '' );
+		$title      = sanitize_text_field( $input['title'] ?? '' );
+
+		if ( ! $post_id || empty( $element_id ) || '' === $title ) {
+			return new \WP_Error( 'missing_params', __( 'post_id, element_id, and title are required.', 'emcp-tools' ) );
+		}
+
+		$page_data = $this->data->get_page_data( $post_id );
+
+		if ( is_wp_error( $page_data ) ) {
+			return $page_data;
+		}
+
+		if ( null === $this->data->find_element_by_id( $page_data, $element_id ) ) {
+			return new \WP_Error( 'element_not_found', __( 'Element not found.', 'emcp-tools' ) );
+		}
+
+		// editor_settings is a sibling-root key; update_element_settings() hoists
+		// it out of the settings payload and deep-merges it into the element root.
+		$updated = $this->data->update_element_settings(
+			$page_data,
+			$element_id,
+			array( 'editor_settings' => array( 'title' => $title ) )
+		);
+
+		if ( ! $updated ) {
+			return new \WP_Error( 'update_failed', __( 'Failed to set element label.', 'emcp-tools' ) );
+		}
+
+		$result = $this->data->save_page_data( $post_id, $page_data );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return array(
+			'success'    => true,
+			'element_id' => $element_id,
+			'title'      => $title,
 		);
 	}
 

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -2102,12 +2102,17 @@ class EMCP_Tools_Admin {
 					),
 					'emcp-tools/update-element'       => array(
 						'label'       => __( 'Update Element', 'emcp-tools' ),
-						'description' => __( 'Updates settings on any element (widget or container) by ID.', 'emcp-tools' ),
+						'description' => __( 'Updates settings on any element (widget or container) by ID. Also writes v4 atomic styles / editor_settings when included.', 'emcp-tools' ),
 						'badges'      => array(),
 					),
 					'emcp-tools/batch-update'         => array(
 						'label'       => __( 'Batch Update', 'emcp-tools' ),
 						'description' => __( 'Applies multiple element updates in a single call.', 'emcp-tools' ),
+						'badges'      => array(),
+					),
+					'emcp-tools/set-element-label'    => array(
+						'label'       => __( 'Set Element Label', 'emcp-tools' ),
+						'description' => __( 'Sets an element\'s Navigator label (editor_settings.title).', 'emcp-tools' ),
 						'badges'      => array(),
 					),
 					'emcp-tools/reorder-elements'     => array(

--- a/includes/class-atomic-props.php
+++ b/includes/class-atomic-props.php
@@ -143,10 +143,15 @@ class EMCP_Tools_Atomic_Props {
 	}
 
 	/**
-	 * Wraps a WordPress media image reference.
+	 * Wraps a WordPress media image reference for the atomic `e-image` widget.
 	 *
-	 * @param int    $image_id  The attachment ID.
-	 * @param string $image_url The image URL (optional fallback).
+	 * Elementor's Image_Src_Prop_Type enforces `id XOR url` — exactly one of the
+	 * two may be set, the other MUST be null — and the id must be an
+	 * `image-attachment-id`, not a plain `number`. Passing both (or a `number`
+	 * id) makes Elementor reject the value with `image: invalid_value` (#74).
+	 *
+	 * @param int    $image_id  The attachment ID (0 to use a url instead).
+	 * @param string $image_url The image URL (used only when $image_id is 0).
 	 * @return array Typed image prop.
 	 */
 	public static function image( int $image_id, string $image_url = '' ): array {
@@ -154,10 +159,54 @@ class EMCP_Tools_Atomic_Props {
 			'$$type' => 'image',
 			'value'  => array(
 				'src' => array(
-					'id'  => self::number( $image_id ),
-					'url' => self::url( $image_url ),
+					'$$type' => 'image-src',
+					'value'  => self::image_src_value( $image_id, $image_url ),
 				),
 			),
+		);
+	}
+
+	/**
+	 * Wraps a WordPress media SVG reference for the atomic `e-svg` widget.
+	 *
+	 * The `e-svg` widget's `svg` prop is a distinct `svg-src` type — NOT the
+	 * `image`/`image-src` type used by `e-image` — so it must not be built with
+	 * image() (#74). Its shape mirrors image-src (id/url) with at least one set.
+	 *
+	 * @param int    $svg_id  The attachment ID (0 to use a url instead).
+	 * @param string $svg_url The SVG URL (used only when $svg_id is 0).
+	 * @return array Typed svg-src prop.
+	 */
+	public static function svg( int $svg_id, string $svg_url = '' ): array {
+		return array(
+			'$$type' => 'svg-src',
+			'value'  => self::image_src_value( $svg_id, $svg_url ),
+		);
+	}
+
+	/**
+	 * Builds the inner id/url value shared by image-src and svg-src: an
+	 * `image-attachment-id` when an id is given (url null), otherwise a `url`
+	 * (id null).
+	 *
+	 * @param int    $id  The attachment ID (0 to use a url).
+	 * @param string $url The URL (used only when $id is 0).
+	 * @return array{id:?array,url:?array}
+	 */
+	private static function image_src_value( int $id, string $url ): array {
+		if ( $id > 0 ) {
+			return array(
+				'id'  => array(
+					'$$type' => 'image-attachment-id',
+					'value'  => $id,
+				),
+				'url' => null,
+			);
+		}
+
+		return array(
+			'id'  => null,
+			'url' => '' === $url ? null : self::url( $url ),
 		);
 	}
 
@@ -207,11 +256,28 @@ class EMCP_Tools_Atomic_Props {
 
 				case 'image':
 					if ( is_array( $value ) && isset( $value['src'] ) && is_array( $value['src'] ) ) {
+						// src is wrapped as {$$type:image-src, value:{id,url}}; an
+						// older/bare {id,url} shape is tolerated for round-trips.
+						$src = isset( $value['src']['$$type'], $value['src']['value'] ) && is_array( $value['src']['value'] )
+							? $value['src']['value']
+							: $value['src'];
 						return array(
-							'id'  => self::unwrap( $value['src']['id'] ?? 0 ),
-							'url' => self::unwrap( $value['src']['url'] ?? '' ),
+							'id'  => self::unwrap( $src['id'] ?? 0 ),
+							'url' => self::unwrap( $src['url'] ?? '' ),
 						);
 					}
+					return $value;
+
+				case 'svg-src':
+					if ( is_array( $value ) ) {
+						return array(
+							'id'  => self::unwrap( $value['id'] ?? 0 ),
+							'url' => self::unwrap( $value['url'] ?? '' ),
+						);
+					}
+					return $value;
+
+				case 'image-attachment-id':
 					return $value;
 
 				default:

--- a/includes/class-elementor-data.php
+++ b/includes/class-elementor-data.php
@@ -443,6 +443,28 @@ class EMCP_Tools_Data {
 					$item['settings'] = array();
 				}
 
+				// Sibling-root keys: on v4 atomic elements the local `styles`
+				// map and `editor_settings` (Navigator label = editor_settings.
+				// title) live at the element ROOT, as siblings of `settings`.
+				// An agent naturally nests them under `settings`; hoist them out
+				// and deep-merge into the root so they actually persist instead
+				// of being written to a dead `settings.styles` key (#72, #73).
+				foreach ( array( 'styles', 'editor_settings' ) as $root_key ) {
+					if ( ! array_key_exists( $root_key, $settings ) ) {
+						continue;
+					}
+
+					$incoming = $settings[ $root_key ];
+					unset( $settings[ $root_key ] );
+
+					if ( is_array( $incoming ) ) {
+						$existing = isset( $item[ $root_key ] ) && is_array( $item[ $root_key ] ) ? $item[ $root_key ] : array();
+						$item[ $root_key ] = self::deep_merge( $existing, $incoming );
+					} else {
+						$item[ $root_key ] = $incoming;
+					}
+				}
+
 				// Containers: rewrite MCP shorthand keys (`justify_content`,
 				// `align_items`, `align_content`) to Elementor's prefixed flex
 				// keys before merging. Without this, the values are saved
@@ -463,5 +485,55 @@ class EMCP_Tools_Data {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Recursively merges $incoming into $existing. Associative arrays are merged
+	 * key-by-key; lists (numeric-keyed arrays, e.g. a `variants` array) and
+	 * scalars are replaced wholesale by the incoming value. This lets a partial
+	 * `styles`/`editor_settings` update touch one class or key without dropping
+	 * the siblings, while still replacing a variants list the caller supplied in
+	 * full.
+	 *
+	 * @since 3.2.1
+	 *
+	 * @param array $existing The current value.
+	 * @param array $incoming The value to merge in (wins on conflicts).
+	 * @return array The merged array.
+	 */
+	private static function deep_merge( array $existing, array $incoming ): array {
+		foreach ( $incoming as $key => $value ) {
+			if (
+				is_string( $key )
+				&& isset( $existing[ $key ] )
+				&& is_array( $existing[ $key ] )
+				&& is_array( $value )
+				&& self::is_assoc( $existing[ $key ] )
+				&& self::is_assoc( $value )
+			) {
+				$existing[ $key ] = self::deep_merge( $existing[ $key ], $value );
+			} else {
+				$existing[ $key ] = $value;
+			}
+		}
+
+		return $existing;
+	}
+
+	/**
+	 * Whether an array is associative (has any string key / non-sequential
+	 * integer keys). An empty array is treated as a list (not associative).
+	 *
+	 * @since 3.2.1
+	 *
+	 * @param array $arr The array to test.
+	 * @return bool
+	 */
+	private static function is_assoc( array $arr ): bool {
+		if ( array() === $arr ) {
+			return false;
+		}
+
+		return array_keys( $arr ) !== range( 0, count( $arr ) - 1 );
 	}
 }


### PR DESCRIPTION
Fixes three atomic-element write bugs reported by @gthibo on Elementor 4.1.x (v4 atomic), verified against Elementor 4.1.4's actual prop-type source.

## #74 — add-atomic-image / add-atomic-svg reject a valid image_id/image_url

`EMCP_Tools_Atomic_Props::image()` emitted **both** an id **and** a (wrapped, empty) url, with the id typed as a plain `number`. But Elementor's `Image_Src_Prop_Type` enforces **id XOR url** (exactly one, the other null) and requires the id to be an `image-attachment-id` — so the value was rejected with `image: invalid_value`. And `e-svg` uses a **distinct** `svg-src` prop (no outer `image`/`src` nesting), so `add-atomic-svg` reusing `image()` was doubly wrong.

**Fix:** `image()` now builds `image → image-src → image-attachment-id` with the unused side nulled; a new `svg()` builder emits `svg-src`; `unwrap()` descends the new nesting and handles `svg-src`. `add-atomic-svg` now uses `svg()`.

## #72 / #73 — styles map and editor_settings not writable

On atomic elements the local `styles` map and `editor_settings` (Navigator label = `editor_settings.title`) are **sibling-root** keys, but `update_element_settings()` merged everything into `settings`, so they landed at a dead `settings.styles` / `settings.editor_settings` and were silently dropped (the call still returned success).

**Fix:** hoist those two keys out of the incoming settings and **deep-merge** them into the element root. `update-element`, `batch-update`, and `update-atomic-widget` all inherit it. Deep-merge replaces lists/scalars wholesale but merges associative maps, so a partial `styles` update keeps untouched local classes.

## Also

- New `emcp-tools/set-element-label` tool (layout group) — convenience wrapper for the common Navigator-rename case.
- Tool descriptions updated so agents discover the `styles`/`editor_settings` support.

## Tests

`pro/tests`: `AtomicImageEnvelopeRegressionTest`, `AtomicWriteGapRegressionTest`; `LayoutCapabilityTest` now expects 9 layout tools. **Full suite 928 green.**

Closes #72
Closes #73
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)