### PR TITLE
fix(content): accept array post_type/status in list-posts

### DIFF
--- a/includes/abilities/class-content-abilities.php
+++ b/includes/abilities/class-content-abilities.php
@@ -853,16 +853,23 @@ class EMCP_Tools_Content_Abilities {
 		$orderby  = in_array( $input['orderby'] ?? '', array( 'date', 'modified', 'title', 'menu_order', 'ID' ), true ) ? $input['orderby'] : 'date';
 		$order    = ( isset( $input['order'] ) && 'ASC' === strtoupper( (string) $input['order'] ) ) ? 'ASC' : 'DESC';
 
-		$post_type = isset( $input['post_type'] ) ? sanitize_key( (string) $input['post_type'] ) : 'post';
-		if ( '' === $post_type ) {
+		$pt_raw    = $input['post_type'] ?? 'post';
+		$post_type = is_array( $pt_raw )
+			? array_values( array_filter( array_map( 'sanitize_key', $pt_raw ) ) )
+			: sanitize_key( (string) $pt_raw );
+		if ( empty( $post_type ) ) {
 			$post_type = 'post';
 		}
-		$status_in = isset( $input['status'] ) ? (string) $input['status'] : 'any';
-		$status    = in_array(
-			$status_in,
-			array( 'publish', 'future', 'draft', 'pending', 'private', 'trash', 'any' ),
-			true
-		) ? $status_in : 'any';
+		$valid_status = array( 'publish', 'future', 'draft', 'pending', 'private', 'trash', 'any' );
+		$status_raw   = $input['status'] ?? 'any';
+		if ( is_array( $status_raw ) ) {
+			$status = array_values( array_intersect( array_map( 'sanitize_key', $status_raw ), $valid_status ) );
+			if ( empty( $status ) || in_array( 'any', $status, true ) ) {
+				$status = 'any';
+			}
+		} else {
+			$status = in_array( (string) $status_raw, $valid_status, true ) ? (string) $status_raw : 'any';
+		}
 
 		$args = array(
 			'post_type'      => $post_type,


### PR DESCRIPTION
# accept array `post_type` / `status` in `list-posts`

**Branch:** `fix/list-posts-array-type-status`
**File:** `includes/abilities/class-content-abilities.php`

## Why

`list-posts`' schema declares `post_type` and `status` as **string or array**, but
`execute_list_posts()` cast each with `(string)`, so an array became the literal
`"Array"`: `post_type` then matched a non-existent type (**empty result**) and
`status` fell back to `"any"` (**filter ignored**) — both silently. `WP_Query`
natively accepts arrays for `post_type` / `post_status`, so this normalises the
input (sanitising each element) instead of stringifying it. Scalar inputs behave
exactly as before; the default (empty) cases still resolve to `post` / `any`.

## Diff

```diff
@@ execute_list_posts()
-		$post_type = isset( $input['post_type'] ) ? sanitize_key( (string) $input['post_type'] ) : 'post';
-		if ( '' === $post_type ) {
+		$pt_raw    = $input['post_type'] ?? 'post';
+		$post_type = is_array( $pt_raw )
+			? array_values( array_filter( array_map( 'sanitize_key', $pt_raw ) ) )
+			: sanitize_key( (string) $pt_raw );
+		if ( empty( $post_type ) ) {
 			$post_type = 'post';
 		}
-		$status_in = isset( $input['status'] ) ? (string) $input['status'] : 'any';
-		$status    = in_array(
-			$status_in,
-			array( 'publish', 'future', 'draft', 'pending', 'private', 'trash', 'any' ),
-			true
-		) ? $status_in : 'any';
+		$valid_status = array( 'publish', 'future', 'draft', 'pending', 'private', 'trash', 'any' );
+		$status_raw   = $input['status'] ?? 'any';
+		if ( is_array( $status_raw ) ) {
+			$status = array_values( array_intersect( array_map( 'sanitize_key', $status_raw ), $valid_status ) );
+			if ( empty( $status ) || in_array( 'any', $status, true ) ) {
+				$status = 'any';
+			}
+		} else {
+			$status = in_array( (string) $status_raw, $valid_status, true ) ? (string) $status_raw : 'any';
+		}
```

Closes #80
