### PR TITLE
fix: unique .mcpb manifest name per site so bundles don't overwrite (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to MCP Tools for Elementor are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **`.mcpb` bundles for multiple sites overwrote each other in Claude Desktop.** Every generated bundle used the same manifest `name` (`emcp-tools`), and Claude Desktop identifies installed extensions by that field — so installing a second site's bundle silently replaced the first. The bundle name is now unique per site (`emcp-tools-<host-slug>`, e.g. `emcp-tools-staging-example-co-uk`), so bundles for different sites install side by side. `display_name` and everything else are unchanged. Thanks to @Threadcrapper for the report and diagnosis ([#86](https://github.com/msrbuilds/elementor-mcp/issues/86)).
+
 ## [3.2.1]
 
 > A feature + fix release. **ACF / ACF PRO** becomes a first-class integration — exposed as **two dispatcher tools** (`acf-read` / `acf-write`) behind a new **Plugins** tab — letting an agent build a whole content structure (custom post type → taxonomy → field group → posts with values) end to end. Atomic-element writes get three fixes so v4 pages actually persist. New tools round out AI publishing: **`set-social-image`** fixes wrong social link-previews, and a **`full_bleed`** container preset kills the white strips on Canvas pages. Plus a new **`emcp-plugins`** agent skill, a couple of content-query fixes, and admin polish.

--- a/includes/admin/class-mcpb-builder.php
+++ b/includes/admin/class-mcpb-builder.php
@@ -39,11 +39,15 @@ class EMCP_Tools_Mcpb_Builder {
 	 */
 	public static function build_manifest( string $site_url, string $username, string $app_password ): array {
 		$host    = (string) wp_parse_url( $site_url, PHP_URL_HOST );
+		$slug    = self::host_slug( $host );
 		$version = defined( 'EMCP_TOOLS_VERSION' ) ? EMCP_TOOLS_VERSION : '0.0.0';
 
 		return array(
 			'manifest_version' => self::MANIFEST_VERSION,
-			'name'             => 'emcp-tools',
+			// Unique per site: Claude Desktop identifies extensions by the
+			// manifest `name`, so a fixed name makes each install silently
+			// overwrite the previous site's bundle. See #86.
+			'name'             => '' !== $slug ? 'emcp-tools-' . $slug : 'emcp-tools',
 			'display_name'     => sprintf( 'EMCP Tools — %s', $host ),
 			'version'          => $version,
 			'description'      => sprintf( 'Connect Claude Desktop to %s for Elementor and WordPress management via MCP.', $host ),
@@ -70,6 +74,22 @@ class EMCP_Tools_Mcpb_Builder {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Derive a Claude-Desktop-safe, per-site suffix from the site host.
+	 *
+	 * Claude Desktop keys installed extensions by the manifest `name` (not the
+	 * filename or `display_name`), so the name must be unique per site or a
+	 * second install replaces the first. e.g. "staging.example.co.uk" →
+	 * "staging-example-co-uk".
+	 *
+	 * @param string $host wp_parse_url() host component.
+	 * @return string Lower-case slug, or '' when the host yields no slug.
+	 */
+	private static function host_slug( string $host ): string {
+		$slug = preg_replace( '/[^a-z0-9]+/', '-', strtolower( $host ) );
+		return trim( (string) $slug, '-' );
 	}
 
 	/**

--- a/tests/McpbBuilderTest.php
+++ b/tests/McpbBuilderTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for EMCP_Tools_Mcpb_Builder::build_manifest().
+ *
+ * Focus: the manifest `name` must be unique per site so installing a second
+ * site's bundle in Claude Desktop does not overwrite the first (issue #86).
+ *
+ * Self-contained: requires the builder class and stubs wp_parse_url() (which
+ * the public bootstrap doesn't define), so it doesn't touch the shared harness.
+ *
+ * @package EMCP_Tools
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once EMCP_TOOLS_DIR . 'includes/admin/class-mcpb-builder.php';
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+
+final class McpbBuilderTest extends TestCase {
+
+	private function manifest( string $site_url ): array {
+		return EMCP_Tools_Mcpb_Builder::build_manifest( $site_url, 'admin', 'app pass word' );
+	}
+
+	public function test_name_is_derived_from_host(): void {
+		$m = $this->manifest( 'https://example.com' );
+		$this->assertSame( 'emcp-tools-example-com', $m['name'] );
+	}
+
+	public function test_two_sites_get_distinct_names(): void {
+		$a = $this->manifest( 'https://alpha.example.com' );
+		$b = $this->manifest( 'https://beta.example.org' );
+
+		// The actual regression from #86: different sites must not collide.
+		$this->assertNotSame( $a['name'], $b['name'] );
+		$this->assertSame( 'emcp-tools-alpha-example-com', $a['name'] );
+		$this->assertSame( 'emcp-tools-beta-example-org', $b['name'] );
+	}
+
+	public function test_subdomain_and_multi_part_tld_are_slugged(): void {
+		$m = $this->manifest( 'https://staging.example.co.uk' );
+		$this->assertSame( 'emcp-tools-staging-example-co-uk', $m['name'] );
+	}
+
+	public function test_host_is_lowercased(): void {
+		$m = $this->manifest( 'https://Example.COM' );
+		$this->assertSame( 'emcp-tools-example-com', $m['name'] );
+	}
+
+	public function test_ip_host_ignores_port(): void {
+		$m = $this->manifest( 'http://192.168.1.10:8080' );
+		$this->assertSame( 'emcp-tools-192-168-1-10', $m['name'] );
+	}
+
+	public function test_falls_back_to_base_name_when_host_absent(): void {
+		// Defensive: a hostless value yields the original stable name.
+		$m = $this->manifest( '' );
+		$this->assertSame( 'emcp-tools', $m['name'] );
+	}
+
+	public function test_display_name_remains_per_host(): void {
+		$m = $this->manifest( 'https://example.com' );
+		$this->assertSame( 'EMCP Tools — example.com', $m['display_name'] );
+	}
+
+	public function test_credentials_are_embedded_in_env(): void {
+		$env = $this->manifest( 'https://example.com' )['server']['mcp_config']['env'];
+		$this->assertSame( 'https://example.com', $env['WP_URL'] );
+		$this->assertSame( 'admin', $env['WP_USERNAME'] );
+		$this->assertSame( 'app pass word', $env['WP_APP_PASSWORD'] );
+	}
+}


### PR DESCRIPTION
Fixes #86.

## What & why

Every generated `.mcpb` bundle sets the same manifest `name`:

```json
"name": "emcp-tools"
```

Claude Desktop identifies installed extensions by that `name` field (not the filename or `display_name`), so installing the bundle for a second site **silently replaces** the first site's extension. Multi-site users can only keep one connected at a time. Thanks to @Threadcrapper for the clear report and diagnosis.

## Fix

`EMCP_Tools_Mcpb_Builder::build_manifest()` already interpolates the host into `display_name`; this makes `name` unique the same way:

```php
'name' => '' !== $slug ? 'emcp-tools-' . $slug : 'emcp-tools',
```

A small `host_slug()` helper turns the host into a Claude-Desktop-safe suffix — lower-cased, non-alphanumerics collapsed to `-`:

| Site | `name` |
|---|---|
| `https://example.com` | `emcp-tools-example-com` |
| `https://staging.example.co.uk` | `emcp-tools-staging-example-co-uk` |
| `http://192.168.1.10:8080` | `emcp-tools-192-168-1-10` |

If the host yields no slug (empty / malformed), it falls back to the original `emcp-tools`, so nothing regresses. `display_name`, the embedded credentials, and the proxy are all unchanged.

## Files

- `includes/admin/class-mcpb-builder.php` — `host_slug()` helper + per-site `name`.
- `tests/McpbBuilderTest.php` (new) — self-contained; stubs `wp_parse_url()` (which `tests/bootstrap.php` doesn't define) so it doesn't touch the shared harness.
- `CHANGELOG.md` — one line under a new `[Unreleased]`.

## Tests

Ran the whole public suite locally against **PHPUnit 10.5.64 / PHP 8.2** with `phpunit -c tests/phpunit.xml`:

```
OK (57 tests, 148 assertions)
```

That's the existing `AcfAbilitiesTest` (49) plus the 8 new `McpbBuilderTest` cases — the core regression (two different sites → distinct names) plus slug edges (subdomains, multi-part TLDs, lower-casing, IP+port, hostless fallback, credentials-still-embedded). No existing test changed.

## Note (not in this PR)

The issue also points out that the WordPress application password sits in plaintext in `manifest.json` inside the bundle. That's inherent to how Claude Desktop passes env to the server, but I agree it's worth a line in the docs/UI telling users to treat `.mcpb` files as secrets. Happy to send that as a separate docs PR if you'd like — kept it out of here to keep this fix focused.
