### PR TITLE
fix: add `sitePath` function for handling subdirectory WordPress installs

### DIFF
--- a/bin/mcp-proxy.mjs
+++ b/bin/mcp-proxy.mjs
@@ -90,6 +90,17 @@ function normalizeSite(cfg) {
   };
 }
 
+/**
+ * The site's base path, for WordPress installs that live in a subdirectory
+ * (e.g. `https://example.com/blog` → `/blog`). Root installs → `''`.
+ *
+ * @param {Object} site A normalized site object (has `.parsed`, a URL instance).
+ * @returns {string}
+ */
+export function sitePath(site) {
+  return site.parsed.pathname.replace(/\/$/, '');
+}
+
 /** The two injected site-switching tools. */
 export const META_TOOLS = [
   {
@@ -201,7 +212,7 @@ function runProxy() {
       const options = {
         hostname: site.parsed.hostname,
         port: site.parsed.port || (isHttps ? 443 : 80),
-        path: '/wp-json/', method: 'HEAD', headers: { Accept: 'application/json' },
+        path: `${sitePath(site)}/wp-json/`, method: 'HEAD', headers: { Accept: 'application/json' },
       };
       if (isHttps && site.isLocalDev) options.rejectUnauthorized = false;
       const { statusCode } = await doHttpRequest(site, options, '');
@@ -210,7 +221,8 @@ function runProxy() {
   }
 
   function mcpPath(alias) {
-    return state.permalinks[alias] ? '/wp-json' + MCP_REST_PATH : '/?rest_route=' + encodeURIComponent(MCP_REST_PATH);
+    const basePath = sitePath(state.sites[alias]);
+    return state.permalinks[alias] ? `${basePath}/wp-json${MCP_REST_PATH}` : `${basePath}/?rest_route=${encodeURIComponent(MCP_REST_PATH)}`;
   }
 
   async function sendToSite(alias, message) {
@@ -279,7 +291,7 @@ function runProxy() {
 
       const trimmed = body.trim();
       if (!trimmed) return;
-      let output = trimmed;
+      let output;
       try {
         const parsed = JSON.parse(trimmed);
         if (method === 'initialize' && MCP_PROTOCOL_VERSION && parsed.result?.protocolVersion) {
@@ -287,7 +299,16 @@ function runProxy() {
         }
         if (method === 'tools/list') injectMetaTools(parsed, siteCount);
         output = JSON.stringify(parsed);
-      } catch { /* not JSON — forward as-is */ }
+      } catch {
+        // Never forward non-JSON upstream bodies to stdout — that corrupts the
+        // stdio JSON-RPC framing and kills the connection.
+        logStderr(`Non-JSON upstream response for id=${id}: ${trimmed.slice(0, 2000)}`);
+        output = JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32603, message: 'Upstream returned a non-JSON response', data: { body: trimmed.slice(0, 1000) } },
+        });
+      }
       process.stdout.write(output + '\n');
     } catch (err) {
       logStderr(`← error: ${err.message}`);

--- a/bin/mcp-proxy.test.mjs
+++ b/bin/mcp-proxy.test.mjs
@@ -6,7 +6,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 process.env.EMCP_PROXY_NO_MAIN = '1';
-const { loadSites, META_TOOLS, isMetaCall, injectMetaTools, handleMetaCall } = await import('./mcp-proxy.mjs');
+const { loadSites, META_TOOLS, isMetaCall, injectMetaTools, handleMetaCall, sitePath } = await import('./mcp-proxy.mjs');
 
 test('loadSites: single-site env → one default site', () => {
   const { sites, defaultSite } = loadSites({
@@ -60,6 +60,21 @@ test('injectMetaTools: appends only when >1 site', () => {
   const names = multi.result.tools.map((t) => t.name);
   assert.ok(names.includes('emcp_use_site'));
   assert.equal(multi.result.tools.length, 3);
+});
+
+test('sitePath: root install → empty string', () => {
+  const { sites } = loadSites({ WP_URL: 'https://a.test', WP_USERNAME: 'u', WP_APP_PASSWORD: 'p' });
+  assert.equal(sitePath(sites.default), '');
+});
+
+test('sitePath: subdirectory install → base path without trailing slash', () => {
+  const { sites } = loadSites({ WP_URL: 'https://a.test/claude2wp', WP_USERNAME: 'u', WP_APP_PASSWORD: 'p' });
+  assert.equal(sitePath(sites.default), '/claude2wp');
+});
+
+test('sitePath: nested subdirectory install', () => {
+  const { sites } = loadSites({ WP_URL: 'https://a.test/sites/client-a', WP_USERNAME: 'u', WP_APP_PASSWORD: 'p' });
+  assert.equal(sitePath(sites.default), '/sites/client-a');
 });
 
 test('handleMetaCall: list + switch', () => {


### PR DESCRIPTION
Closes #93 