### PR TITLE
docs: correct stale Openverse references to the current stock providers (Unsplash, Pexels, Pixabay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A WordPress plugin that extends the [WordPress MCP Adapter](https://github.com/W
 - **Brand Kits** — One-click coordinated color + typography kits. Apply a curated brand kit and the whole site re-skins (system tokens + Theme Style defaults); back up and restore any time. **10 kits are free to apply**; the full 50-kit library and the `apply-brand-kit` MCP tool are Pro
 - **AI Widget Builder (Pro)** — Let an AI agent design custom Elementor widgets from a structured spec — no hand-written PHP. The plugin compiles the spec + an HTML template into a sandboxed `Widget_Base` class (35 control types, optional per-widget CSS/JS) that appears under a "Custom (EMCP)" category in the editor; a runtime safety net keeps a bad widget from breaking the editor
 - **Composite Tools** — Build a complete page from a declarative JSON structure in a single call
-- **Stock Images** — Search Openverse for Creative Commons images, sideload into Media Library, add to pages
+- **Stock Images** — Search Unsplash, Pexels & Pixabay for stock photos, sideload into Media Library, add to pages
 - **SVG Icons** — Upload SVG icons from URL or raw markup for use with Elementor icon widgets
 - **Custom Code** — Add custom CSS (element/page level), inject JavaScript, create site-wide code snippets for head/body injection
 - **Low-tools Mode** — One-click toggle that filters the active tool list to a curated essentials set, for MCP clients with strict tool caps (Antigravity, Gemini API, etc.). After the v3.0.0 widget consolidation the active count already fits most caps, so this is rarely needed now
@@ -494,7 +494,7 @@ These tools only register when Elementor >= 4.0 is detected. Legacy widget tools
 
 | Tool | Description |
 |---|---|
-| `search-images` | Search Openverse for Creative Commons images by keyword |
+| `search-images` | Search Unsplash, Pexels or Pixabay for stock photos by keyword |
 | `sideload-image` | Download an external image URL into the WordPress Media Library |
 | `add-stock-image` | Search + sideload + add image widget to page in one call |
 

--- a/includes/abilities/class-media-library-abilities.php
+++ b/includes/abilities/class-media-library-abilities.php
@@ -4,8 +4,8 @@
  *
  * Registers a single read-only tool, `list-media`, that lets an AI agent
  * discover and query images already uploaded to the WordPress Media Library.
- * This fills the gap left by the Openverse search tools: those find generic
- * Creative Commons stock, but can't surface a client's own photos (e.g. 300+
+ * This fills the gap left by the stock-image search tools: those find generic
+ * stock photos, but can't surface a client's own photos (e.g. 300+
  * job-site images already in their library). Backed by a direct WP_Query on
  * attachments — no HTTP round-trip.
  *
@@ -93,7 +93,7 @@ class EMCP_Tools_Media_Library_Abilities {
 			'emcp-tools/list-media',
 			array(
 				'label'               => __( 'List Media', 'emcp-tools' ),
-				'description'         => __( 'Lists and searches images already in the WordPress Media Library. Use this to find a site\'s own uploaded photos (e.g. a client\'s product or job-site images) before reaching for Openverse stock. The optional "search" matches the title, alt text, caption, and description. Returns attachment IDs and URLs you can pass straight to add-free-widget.', 'emcp-tools' ),
+				'description'         => __( 'Lists and searches images already in the WordPress Media Library. Use this to find a site\'s own uploaded photos (e.g. a client\'s product or job-site images) before reaching for stock photos. The optional "search" matches the title, alt text, caption, and description. Returns attachment IDs and URLs you can pass straight to add-free-widget.', 'emcp-tools' ),
 				'category'            => 'emcp-tools',
 				'execute_callback'    => array( $this, 'execute_list_media' ),
 				'permission_callback' => array( $this, 'check_read_permission' ),

--- a/includes/abilities/class-stock-image-abilities.php
+++ b/includes/abilities/class-stock-image-abilities.php
@@ -3,7 +3,7 @@
  * Stock image MCP abilities for Elementor.
  *
  * Registers 3 tools for searching, sideloading, and adding stock images
- * from the Openverse API (WordPress.org's Creative Commons image search).
+ * from the configured stock provider (Unsplash, Pexels, or Pixabay).
  *
  * @package EMCP_Tools
  * @since   1.1.0

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ As of v3.0.0 the 62 per-widget tools were folded into a catalog-backed model, so
 * **Template Tools**: Save pages or elements as reusable templates, apply templates to pages, theme builder, popups, dynamic tags (Pro).
 * **Global Settings**: Update site-wide color palettes and typography presets.
 * **Composite Tools**: Build a complete page from a declarative JSON structure in a single call.
-* **Stock & Media Images**: Search Openverse for Creative Commons images, sideload into the Media Library, add to pages, plus `list-media` to discover and search the site's own existing uploads (by title, alt text, caption, and description).
+* **Stock & Media Images**: Search Unsplash, Pexels & Pixabay for stock photos, sideload into the Media Library, add to pages, plus `list-media` to discover and search the site's own existing uploads (by title, alt text, caption, and description).
 * **SVG Icons**: Upload SVG icons from URL or raw markup for use with Elementor icon widgets.
 * **Custom Code**: Add custom CSS (element/page level), inject JavaScript, create site-wide code snippets for head/body injection.
 * **AI Widget Builder (Pro)**: Let an AI agent design custom Elementor widgets from a structured spec (no hand-written PHP). The plugin compiles the spec into a sandboxed widget that appears in the Elementor panel: 35 control types, optional CSS/JS, with a runtime safety net so a bad widget can never break the editor.


### PR DESCRIPTION
## What

The stock-image tools migrated from the Openverse API to Unsplash / Pexels / Pixabay back in v3.1.0, but a handful of **current-tense** descriptions still say "Openverse" / "Creative Commons." This corrects them so the docs and in-code descriptions match what the tools actually do today.

## Changes (text only — no logic)

- **`README.md`** — the "Stock Images" feature bullet and the `search-images` row in the tools table.
- **`readme.txt`** — the "Stock & Media Images" feature bullet.
- **`includes/abilities/class-stock-image-abilities.php`** — class docblock (said the tools search "the Openverse API (WordPress.org's Creative Commons image search)").
- **`includes/abilities/class-media-library-abilities.php`** — class docblock, plus the `list-media` tool `description` returned to MCP clients ("before reaching for Openverse stock").

Wording follows the plugin's own terminology (`class-stock-image-abilities.php`: *"Unsplash, Pexels, or Pixabay"*, requires a free API key for at least one provider).

## Intentionally left unchanged

- CHANGELOG / readme changelog entries that mention Openverse — accurate history for the releases they describe.
- The *"old Openverse client"* migration notes in `class-unsplash-client.php` — deliberate context explaining the switch.
