### PR TITLE
fix: return empty string for elementor_pro_version when Elementor Pro is absent

### DIFF
--- a/includes/abilities/class-atomic-layout-abilities.php
+++ b/includes/abilities/class-atomic-layout-abilities.php
@@ -304,7 +304,7 @@ class EMCP_Tools_Atomic_Layout_Abilities {
 				'category'            => 'emcp-tools',
 				'execute_callback'    => function () {
 					$core_version = defined( 'ELEMENTOR_VERSION' ) ? ELEMENTOR_VERSION : 'unknown';
-					$pro_version  = defined( 'ELEMENTOR_PRO_VERSION' ) ? ELEMENTOR_PRO_VERSION : null;
+					$pro_version  = defined( 'ELEMENTOR_PRO_VERSION' ) ? ELEMENTOR_PRO_VERSION : '';
 
 					$supports_atomic    = EMCP_Tools_Atomic_Props::is_atomic_supported();
 					$supports_container = EMCP_Tools_Atomic_Props::is_container_supported();


### PR DESCRIPTION
## Summary

Fixes #116.

The `detect-elementor-version` ability returned `null` for `elementor_pro_version` when `ELEMENTOR_PRO_VERSION` is not defined, but the tool's `output_schema` declares that field as `type: string`. MCP clients that validate outputs reject the response (`output[elementor_pro_version] is not of type string`), making the tool unusable on free-only installs.

## Change

```diff
- $pro_version  = defined( 'ELEMENTOR_PRO_VERSION' ) ? ELEMENTOR_PRO_VERSION : null;
+ $pro_version  = defined( 'ELEMENTOR_PRO_VERSION' ) ? ELEMENTOR_PRO_VERSION : '';
```

## Test

`detect-elementor-version` now returns a valid string for `elementor_pro_version` on a WordPress 7.0.4 / PHP 8.4.23 / Elementor 4.2.2 (free) install:

```json
{ "elementor_version": "4.2.2", "elementor_pro_version": "", "supports_atomic": true, "supports_container": true, "recommended_mode": "atomic" }
```
