### PR TITLE
Fix: Validate global-class writes and parse friendly size units

### DIFF
--- a/includes/abilities/class-global-classes-write-abilities.php
+++ b/includes/abilities/class-global-classes-write-abilities.php
@@ -200,6 +200,11 @@ class EMCP_Tools_Global_Classes_Write_Abilities {
 		}
 		list( $items, $order ) = $state;
 
+		$variant_props = $this->build_variant_props( $input );
+		if ( is_wp_error( $variant_props ) ) {
+			return $variant_props;
+		}
+
 		$id = $this->mint_id( $items );
 		$items[ $id ] = array(
 			'id'       => $id,
@@ -208,7 +213,7 @@ class EMCP_Tools_Global_Classes_Write_Abilities {
 			'variants' => array(
 				array(
 					'meta'  => $this->variant_meta( $input ),
-					'props' => $this->build_variant_props( $input ),
+					'props' => $variant_props,
 				),
 			),
 		);
@@ -249,8 +254,11 @@ class EMCP_Tools_Global_Classes_Write_Abilities {
 
 		$has_styles = ( isset( $input['styles'] ) && is_array( $input['styles'] ) ) || ( isset( $input['props'] ) && is_array( $input['props'] ) );
 		if ( $has_styles ) {
-			$meta     = $this->variant_meta( $input );
+			$meta      = $this->variant_meta( $input );
 			$new_props = $this->build_variant_props( $input );
+			if ( is_wp_error( $new_props ) ) {
+				return $new_props;
+			}
 			$variants = isset( $item['variants'] ) ? (array) $item['variants'] : array();
 			$idx      = $this->find_variant_index( $variants, $meta );
 			$replace  = ! empty( $input['replace_variant'] );
@@ -482,25 +490,141 @@ class EMCP_Tools_Global_Classes_Write_Abilities {
 	}
 
 	/**
+	 * Longhand / CSS names Elementor stores under a different schema key.
+	 *
+	 * @var array<string, string>
+	 */
+	const PROP_ALIASES = array(
+		'padding-top'          => 'padding',
+		'padding-right'        => 'padding',
+		'padding-bottom'       => 'padding',
+		'padding-left'         => 'padding',
+		'padding-block-start'  => 'padding',
+		'padding-block-end'    => 'padding',
+		'padding-inline-start' => 'padding',
+		'padding-inline-end'   => 'padding',
+		'margin-top'           => 'margin',
+		'margin-right'         => 'margin',
+		'margin-bottom'        => 'margin',
+		'margin-left'          => 'margin',
+		'margin-block-start'   => 'margin',
+		'margin-block-end'     => 'margin',
+		'margin-inline-start'  => 'margin',
+		'margin-inline-end'    => 'margin',
+		'border-top-width'     => 'border-width',
+		'border-right-width'   => 'border-width',
+		'border-bottom-width'  => 'border-width',
+		'border-left-width'    => 'border-width',
+		'border-top-style'     => 'border-style',
+		'border-right-style'   => 'border-style',
+		'border-bottom-style'  => 'border-style',
+		'border-left-style'    => 'border-style',
+		'border-top-color'     => 'border-color',
+		'border-right-color'   => 'border-color',
+		'border-bottom-color'  => 'border-color',
+		'border-left-color'    => 'border-color',
+		'flex-grow'            => 'flex',
+		'flex-shrink'          => 'flex',
+		'flex-basis'           => 'flex',
+		'background-color'     => 'background',
+	);
+
+	/**
 	 * Build a variant's props from friendly `styles` + raw `props`.
 	 *
 	 * @param array $input Tool input.
-	 * @return array CSS prop => $$type map.
+	 * @return array|\WP_Error CSS prop => $$type map.
 	 */
-	private function build_variant_props( array $input ): array {
+	private function build_variant_props( array $input ) {
 		$styles = ( isset( $input['styles'] ) && is_array( $input['styles'] ) ) ? $input['styles'] : array();
 		$props  = array();
 		if ( ! empty( $styles ) && class_exists( 'EMCP_Tools_Atomic_Styles' ) ) {
-			$props = array_merge(
-				EMCP_Tools_Atomic_Styles::build_common_props( $styles ),
-				EMCP_Tools_Atomic_Styles::build_flex_props( $styles )
-			);
+			$common = EMCP_Tools_Atomic_Styles::build_common_props( $styles );
+			if ( is_wp_error( $common ) ) {
+				return $common;
+			}
+			$flex = EMCP_Tools_Atomic_Styles::build_flex_props( $styles );
+			if ( is_wp_error( $flex ) ) {
+				return $flex;
+			}
+			$props = array_merge( $common, $flex );
 		}
 		if ( isset( $input['props'] ) && is_array( $input['props'] ) ) {
+			$rejected = $this->rejected_style_props( $input['props'] );
+			if ( ! empty( $rejected ) ) {
+				return new \WP_Error(
+					'unsupported_style_props',
+					sprintf(
+						/* translators: %s: property names and hints */
+						__( 'These style properties are not in Elementor\'s Global Class schema and would be silently discarded: %s', 'emcp-tools' ),
+						implode( '; ', $rejected )
+					),
+					array( 'status' => 400, 'rejected' => array_keys( $rejected ) )
+				);
+			}
 			// Raw escape hatch wins over built styles for the same key.
 			$props = array_merge( $props, $input['props'] );
 		}
+
 		return $props;
+	}
+
+	/**
+	 * Keys Elementor will keep when compiling Global Class CSS.
+	 *
+	 * @return string[]
+	 */
+	public static function allowed_style_prop_keys(): array {
+		if ( class_exists( '\\Elementor\\Modules\\AtomicWidgets\\Styles\\Style_Schema' ) ) {
+			$schema = \Elementor\Modules\AtomicWidgets\Styles\Style_Schema::get();
+			if ( is_array( $schema ) && ! empty( $schema ) ) {
+				return array_keys( $schema );
+			}
+		}
+
+		return array(
+			'width', 'height', 'min-width', 'min-height', 'max-width', 'max-height',
+			'overflow', 'aspect-ratio', 'object-fit', 'object-position',
+			'position', 'inset-block-start', 'inset-inline-end', 'inset-block-end', 'inset-inline-start',
+			'z-index', 'scroll-margin-top',
+			'font-family', 'font-weight', 'font-size', 'color', 'letter-spacing', 'word-spacing',
+			'column-count', 'column-gap', 'line-height', 'text-align', 'font-style',
+			'text-decoration', 'text-transform', 'direction', 'stroke', 'all', 'cursor',
+			'padding', 'margin',
+			'border-radius', 'border-width', 'border-color', 'border-style',
+			'outline-width', 'outline-color', 'outline-style', 'outline-offset',
+			'background',
+			'mix-blend-mode', 'box-shadow', 'opacity', 'filter', 'backdrop-filter', 'transform', 'transition',
+			'display', 'flex-direction', 'gap', 'flex-wrap', 'flex',
+			'grid-template-columns', 'grid-template-rows', 'grid-auto-flow', 'grid-auto-rows',
+			'grid-auto-columns', 'grid-column', 'grid-row',
+			'justify-content', 'justify-items', 'align-items', 'align-self', 'align-content',
+		);
+	}
+
+	/**
+	 * Human-readable reasons for props Elementor would drop.
+	 *
+	 * @param array $props Built variant props.
+	 * @return array<string, string> rejected key => hint
+	 */
+	public function rejected_style_props( array $props ): array {
+		$allowed  = array_fill_keys( self::allowed_style_prop_keys(), true );
+		$rejected = array();
+
+		foreach ( array_keys( $props ) as $key ) {
+			$key = (string) $key;
+			if ( isset( $allowed[ $key ] ) ) {
+				continue;
+			}
+			if ( isset( self::PROP_ALIASES[ $key ] ) ) {
+				$rejected[ $key ] = sprintf( '%s (use "%s")', $key, self::PROP_ALIASES[ $key ] );
+				continue;
+			}
+			$rejected[ $key ] = sprintf( '%s (not in the atomic style schema)', $key );
+		}
+
+		return $rejected;
 	}
 
 	/**

--- a/includes/class-atomic-props.php
+++ b/includes/class-atomic-props.php
@@ -254,6 +254,79 @@ class EMCP_Tools_Atomic_Props {
 	}
 
 	/**
+	 * Parse a friendly size (number, "100%", or clamp()/var()) into { size, unit }.
+	 *
+	 * Casting every string through `(float)` used to turn `100%` into `100px`
+	 * and `clamp(...)` into `0`. Callers must treat null as "unparseable".
+	 *
+	 * @since 3.14.0
+	 *
+	 * @param mixed  $value         Raw input.
+	 * @param string $explicit_unit Optional unit from a sibling `*_unit` key.
+	 * @return array{size:int|float|string,unit:string}|null
+	 */
+	public static function parse_size_input( $value, string $explicit_unit = '' ): ?array {
+		if ( is_array( $value ) ) {
+			if ( isset( $value['$$type'], $value['value'] ) && is_array( $value['value'] ) && isset( $value['value']['size'] ) ) {
+				$unit = (string) ( $value['value']['unit'] ?? ( '' !== $explicit_unit ? $explicit_unit : 'px' ) );
+				return array(
+					'size' => $value['value']['size'],
+					'unit' => $unit,
+				);
+			}
+			if ( isset( $value['size'] ) ) {
+				return array(
+					'size' => $value['size'],
+					'unit' => (string) ( $value['unit'] ?? ( '' !== $explicit_unit ? $explicit_unit : 'px' ) ),
+				);
+			}
+			return null;
+		}
+
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return array(
+				'size' => $value,
+				'unit' => '' !== $explicit_unit ? $explicit_unit : 'px',
+			);
+		}
+
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$raw = trim( $value );
+		if ( '' === $raw ) {
+			return null;
+		}
+
+		if ( 'custom' === $explicit_unit || preg_match( '/^(clamp|min|max|calc|var)\s*\(/i', $raw ) ) {
+			return array(
+				'size' => $raw,
+				'unit' => 'custom',
+			);
+		}
+
+		if ( preg_match( '/^([+-]?\d*\.?\d+)\s*(px|%|em|rem|vh|vw|vmin|vmax|ch|ex|cm|mm|in|pt|pc|svw|svh|lvw|lvh|dvw|dvh|fr)?$/i', $raw, $matches ) ) {
+			$unit = ( isset( $matches[2] ) && '' !== $matches[2] )
+				? $matches[2]
+				: ( '' !== $explicit_unit ? $explicit_unit : 'px' );
+			return array(
+				'size' => (float) $matches[1],
+				'unit' => $unit,
+			);
+		}
+
+		if ( is_numeric( $raw ) ) {
+			return array(
+				'size' => (float) $raw,
+				'unit' => '' !== $explicit_unit ? $explicit_unit : 'px',
+			);
+		}
+
+		return null;
+	}
+
+	/**
 	 * Wraps a color into a typed prop.
 	 *
 	 * Elementor's `color` style prop is a Color_Prop_Type, so it needs the

--- a/includes/class-atomic-styles.php
+++ b/includes/class-atomic-styles.php
@@ -131,7 +131,7 @@ class EMCP_Tools_Atomic_Styles {
 	 * @param array $params Flat layout parameters from AI agent input.
 	 * @return array CSS props in $$type format (e.g., flex-direction, justify-content, etc.)
 	 */
-	public static function build_flex_props( array $params ): array {
+	public static function build_flex_props( array $params ) {
 		$props = array();
 
 		$string_mappings = array(
@@ -151,19 +151,15 @@ class EMCP_Tools_Atomic_Styles {
 			}
 		}
 
-		if ( isset( $params['gap'] ) ) {
-			$unit = $params['gap_unit'] ?? 'px';
-			$props['gap'] = EMCP_Tools_Atomic_Props::size( (float) $params['gap'], $unit );
-		}
-
-		if ( isset( $params['row_gap'] ) ) {
-			$unit = $params['row_gap_unit'] ?? 'px';
-			$props['row-gap'] = EMCP_Tools_Atomic_Props::size( (float) $params['row_gap'], $unit );
-		}
-
-		if ( isset( $params['column_gap'] ) ) {
-			$unit = $params['column_gap_unit'] ?? 'px';
-			$props['column-gap'] = EMCP_Tools_Atomic_Props::size( (float) $params['column_gap'], $unit );
+		foreach ( array( 'gap' => 'gap', 'row_gap' => 'row-gap', 'column_gap' => 'column-gap' ) as $input_key => $css_prop ) {
+			if ( ! isset( $params[ $input_key ] ) ) {
+				continue;
+			}
+			$parsed = self::size_or_error( $params, $input_key );
+			if ( is_wp_error( $parsed ) ) {
+				return $parsed;
+			}
+			$props[ $css_prop ] = $parsed;
 		}
 
 		return $props;
@@ -173,9 +169,9 @@ class EMCP_Tools_Atomic_Styles {
 	 * Builds common style props (padding, margin, background, etc.) from AI input.
 	 *
 	 * @param array $params Flat style parameters.
-	 * @return array CSS props in $$type format.
+	 * @return array|\WP_Error CSS props in $$type format.
 	 */
-	public static function build_common_props( array $params ): array {
+	public static function build_common_props( array $params ) {
 		$props = array();
 
 		// These are real Elementor style props that take a plain size value.
@@ -186,13 +182,14 @@ class EMCP_Tools_Atomic_Styles {
 		);
 
 		foreach ( $size_mappings as $input_key => $css_prop ) {
-			if ( isset( $params[ $input_key ] ) ) {
-				$unit = $params[ $input_key . '_unit' ] ?? 'px';
-				$props[ $css_prop ] = EMCP_Tools_Atomic_Props::size(
-					(float) $params[ $input_key ],
-					$unit
-				);
+			if ( ! isset( $params[ $input_key ] ) ) {
+				continue;
 			}
+			$parsed = self::size_or_error( $params, $input_key );
+			if ( is_wp_error( $parsed ) ) {
+				return $parsed;
+			}
+			$props[ $css_prop ] = $parsed;
 		}
 
 		// Padding and margin are `dimensions` shorthands. Elementor has no
@@ -210,6 +207,9 @@ class EMCP_Tools_Atomic_Styles {
 				'inline-end'   => 'padding_right',
 			)
 		);
+		if ( is_wp_error( $padding ) ) {
+			return $padding;
+		}
 		if ( null !== $padding ) {
 			$props['padding'] = $padding;
 		}
@@ -224,6 +224,9 @@ class EMCP_Tools_Atomic_Styles {
 				'inline-end'   => 'margin_right',
 			)
 		);
+		if ( is_wp_error( $margin ) ) {
+			return $margin;
+		}
 		if ( null !== $margin ) {
 			$props['margin'] = $margin;
 		}
@@ -257,10 +260,12 @@ class EMCP_Tools_Atomic_Styles {
 	 * @param array  $side_map   Map of dimension side => input key.
 	 * @return array|null Typed dimensions prop, or null when nothing was set.
 	 */
-	private static function build_dimensions( array $params, string $shorthand, array $side_map ): ?array {
+	private static function build_dimensions( array $params, string $shorthand, array $side_map ) {
 		if ( isset( $params[ $shorthand ] ) ) {
-			$unit = $params[ $shorthand . '_unit' ] ?? 'px';
-			$val  = EMCP_Tools_Atomic_Props::size( (float) $params[ $shorthand ], $unit );
+			$val = self::size_or_error( $params, $shorthand );
+			if ( is_wp_error( $val ) ) {
+				return $val;
+			}
 
 			return EMCP_Tools_Atomic_Props::dimensions(
 				array(
@@ -274,13 +279,42 @@ class EMCP_Tools_Atomic_Styles {
 
 		$sides = array();
 		foreach ( $side_map as $dim_side => $input_key ) {
-			if ( isset( $params[ $input_key ] ) ) {
-				$unit               = $params[ $input_key . '_unit' ] ?? 'px';
-				$sides[ $dim_side ] = EMCP_Tools_Atomic_Props::size( (float) $params[ $input_key ], $unit );
+			if ( ! isset( $params[ $input_key ] ) ) {
+				continue;
 			}
+			$parsed = self::size_or_error( $params, $input_key );
+			if ( is_wp_error( $parsed ) ) {
+				return $parsed;
+			}
+			$sides[ $dim_side ] = $parsed;
 		}
 
 		return empty( $sides ) ? null : EMCP_Tools_Atomic_Props::dimensions( $sides );
+	}
+
+	/**
+	 * Build a size prop from a friendly key, or an error if the value would be corrupted.
+	 *
+	 * @param array  $params    Raw input.
+	 * @param string $input_key Friendly key (width, padding_top, …).
+	 * @return array|\WP_Error
+	 */
+	private static function size_or_error( array $params, string $input_key ) {
+		$explicit_unit = isset( $params[ $input_key . '_unit' ] ) ? (string) $params[ $input_key . '_unit' ] : '';
+		$parsed        = EMCP_Tools_Atomic_Props::parse_size_input( $params[ $input_key ], $explicit_unit );
+		if ( null === $parsed ) {
+			return new \WP_Error(
+				'invalid_size',
+				sprintf(
+					/* translators: %s: style input key */
+					__( 'Friendly style "%s" is not a number, a length like "100%%", or a CSS function (clamp/min/max/calc/var). Use raw "props" with a $$type size value instead.', 'emcp-tools' ),
+					$input_key
+				),
+				array( 'status' => 400, 'key' => $input_key )
+			);
+		}
+
+		return EMCP_Tools_Atomic_Props::size( $parsed['size'], $parsed['unit'] );
 	}
 
 	/**

--- a/tests/GlobalClassStyleWriteTest.php
+++ b/tests/GlobalClassStyleWriteTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Public unit tests for Global Class write validation (#125) and friendly
+ * size parsing (#126). The write tools used to report success while Elementor
+ * dropped unknown props, and `(float)` turned `100%` into `100px`.
+ *
+ * @package EMCP_Tools
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	/**
+	 * @param mixed $thing Value to test.
+	 * @return bool
+	 */
+	function is_wp_error( $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	/**
+	 * Minimal WP_Error stand-in for the public test harness.
+	 */
+	class WP_Error {
+		/**
+		 * @var string
+		 */
+		private $code;
+
+		/**
+		 * @var string
+		 */
+		private $message;
+
+		/**
+		 * @param string $code    Error code.
+		 * @param string $message Message.
+		 * @param mixed  $data    Optional data.
+		 */
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			$this->code    = (string) $code;
+			$this->message = (string) $message;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function get_error_code() {
+			return $this->code;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * @param string $text Text.
+	 * @return string
+	 */
+	function __( $text ) {
+		return $text;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/includes/class-atomic-props.php';
+require_once dirname( __DIR__ ) . '/includes/class-atomic-styles.php';
+require_once dirname( __DIR__ ) . '/includes/abilities/class-global-classes-write-abilities.php';
+
+class GlobalClassStyleWriteTest extends \PHPUnit\Framework\TestCase {
+
+	public function test_parses_percentage_string_as_percent_unit() {
+		$parsed = EMCP_Tools_Atomic_Props::parse_size_input( '100%' );
+		$this->assertSame( 100.0, $parsed['size'] );
+		$this->assertSame( '%', $parsed['unit'] );
+	}
+
+	public function test_parses_bare_number_as_px() {
+		$parsed = EMCP_Tools_Atomic_Props::parse_size_input( 16 );
+		$this->assertSame( 16, $parsed['size'] );
+		$this->assertSame( 'px', $parsed['unit'] );
+	}
+
+	public function test_parses_clamp_as_custom_unit() {
+		$parsed = EMCP_Tools_Atomic_Props::parse_size_input( 'clamp(56px,8vw,120px)', 'custom' );
+		$this->assertSame( 'clamp(56px,8vw,120px)', $parsed['size'] );
+		$this->assertSame( 'custom', $parsed['unit'] );
+	}
+
+	public function test_detects_clamp_without_explicit_custom_unit() {
+		$parsed = EMCP_Tools_Atomic_Props::parse_size_input( 'clamp(56px, 8vw, 120px)' );
+		$this->assertSame( 'custom', $parsed['unit'] );
+	}
+
+	public function test_rejects_unparseable_size() {
+		$this->assertNull( EMCP_Tools_Atomic_Props::parse_size_input( 'auto' ) );
+	}
+
+	public function test_friendly_width_percent_is_not_forced_to_px() {
+		$props = EMCP_Tools_Atomic_Styles::build_common_props( array( 'width' => '100%' ) );
+		$this->assertFalse( is_wp_error( $props ) );
+		$this->assertSame( '%', $props['width']['value']['unit'] );
+		$this->assertSame( 100.0, $props['width']['value']['size'] );
+	}
+
+	public function test_friendly_custom_padding_keeps_clamp() {
+		$props = EMCP_Tools_Atomic_Styles::build_common_props(
+			array(
+				'padding_top'      => 'clamp(56px,8vw,120px)',
+				'padding_top_unit' => 'custom',
+			)
+		);
+		$this->assertFalse( is_wp_error( $props ) );
+		$this->assertSame( 'custom', $props['padding']['value']['block-start']['value']['unit'] );
+		$this->assertSame( 'clamp(56px,8vw,120px)', $props['padding']['value']['block-start']['value']['size'] );
+	}
+
+	public function test_rejects_longhand_padding_and_whitespace() {
+		$writer   = new EMCP_Tools_Global_Classes_Write_Abilities();
+		$rejected = $writer->rejected_style_props(
+			array(
+				'color'        => array( '$$type' => 'color', 'value' => 'red' ),
+				'padding-top'  => array( '$$type' => 'size', 'value' => array( 'size' => 5, 'unit' => 'px' ) ),
+				'white-space'  => array( '$$type' => 'string', 'value' => 'nowrap' ),
+			)
+		);
+		$this->assertArrayHasKey( 'padding-top', $rejected );
+		$this->assertArrayHasKey( 'white-space', $rejected );
+		$this->assertArrayNotHasKey( 'color', $rejected );
+		$this->assertStringContainsString( 'padding', $rejected['padding-top'] );
+	}
+}


### PR DESCRIPTION
## Summary

Fixes silent Global Class write failures reported in #125 and #126.

## What changed

- Friendly `styles` sizes are parsed instead of being cast with `(float)`:
  - `width: "100%"` becomes `size: 100, unit: %` (not `100px`)
  - `clamp(...)` / `var(...)` / explicit `*_unit: custom` keep the string and use unit `custom`
  - Unparseable values return an error instead of writing `0`
- Raw `props` are checked against Elementor's atomic style schema (or a fallback key list). Longhands Elementor would drop (`padding-top`, `white-space`, `flex-grow`, …) now fail the tool call with the expected schema key.

## Test plan

- [ ] `create-global-class` with `styles: { width: "100%" }` writes `width:100%` in generated CSS
- [ ] `update-global-class` with `padding_top: "clamp(56px,8vw,120px)"` and `padding_top_unit: "custom"` keeps the clamp
- [ ] `update-global-class` with `props.padding-top` / `props.white-space` returns `unsupported_style_props` and does not persist those keys
- [ ] Valid `props.color` + `props.padding` (dimensions) still succeed
- [ ] Class must be applied on a published page before checking `global-*-frontend-*.css`

Fixes #125
Fixes #126
